### PR TITLE
Show cursor when selecting text

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -46,7 +46,8 @@
                      :dragDrop false
                      :onDragEvent (fn [] true)
                      :undoDepth 10000
-                     :matchBrackets true})]
+                     :matchBrackets true
+                     :showCursorWhenSelecting true})]
     (when-let [c (:content context)]
       (set-val e c)
       (clear-history e))


### PR DESCRIPTION
Fixes issue [#740](https://github.com/LightTable/LightTable/issues/740)
