### PR TITLE
Add osx_deps.sh to grab all the binary dependencies at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,29 +5,10 @@ First install or update [leiningen](http://leiningen.org/). Then we have to do s
 On OS X:
 
 ``` bash
-curl -O http://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.0/LightTableMac.zip
-unzip LightTableMac.zip
-
-mkdir light-table-core-2
-mv LightTable light-table-core-2/deploy
-
 git clone https://github.com/LightTable/LightTable.git
-cp -r LightTable/* light-table-core-2/
+cd LightTable
 
-cd light-table-core-2/deploy
-lein cljsbuild clean && lein cljsbuild once
-
-mv LightTable.app/Contents/Resources/app.nw/plugins plugins
-cd plugins
-rm -rf clojure
-git clone https://github.com/LightTable/Clojure.git clojure
-
-cd clojure
-./build.sh
-
-cd ../../
-rm -rf LightTable.app/Contents/Resources/app.nw
-export LT_HOME=$(pwd)
+sh osx_deps.sh
 ./light
 ```
 

--- a/osx_deps.sh
+++ b/osx_deps.sh
@@ -1,0 +1,26 @@
+#get the LightTable.app binary
+curl -O http://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.0/LightTableMac.zip
+unzip LightTableMac.zip
+mv LightTable/* deploy/
+rmdir LightTable/
+rm LightTableMac.zip
+
+#build the core cljs of LightTable
+lein cljsbuild clean && lein cljsbuild once
+
+#Get the plugins from the binary
+cd deploy
+mv LightTable.app/Contents/Resources/app.nw/plugins plugins
+cd plugins
+
+#Make sure we have the latest clojure
+rm -rf clojure
+git clone https://github.com/LightTable/Clojure.git clojure
+cd clojure
+./build.sh
+
+#Remove the app.nw so we use our local copy
+cd ../../
+rm -rf LightTable.app/Contents/Resources/app.nw
+#Set this as home and run
+export LT_HOME=$(pwd)


### PR DESCRIPTION
As per discussion in #977 a simple shell script for OS X dependencies :) Maybe we can have separate scripts for linux/osx while someone bakes one that works on all platforms?
