### PR TITLE
Remove dead export

### DIFF
--- a/osx_deps.sh
+++ b/osx_deps.sh
@@ -22,5 +22,3 @@ cd clojure
 #Remove the app.nw so we use our local copy
 cd ../../
 rm -rf LightTable.app/Contents/Resources/app.nw
-#Set this as home and run
-export LT_HOME=$(pwd)


### PR DESCRIPTION
Exports in tail position can't possibly do anything unless the script is sourced, but it's not.
