### PR TITLE
Show error message if download fails

### DIFF
--- a/linux_deps.sh
+++ b/linux_deps.sh
@@ -3,7 +3,8 @@ lein version >/dev/null 2>&1 || { echo >&2 "Please install leiningen before runn
 
 echo "### Fetching binaries ###"
 TARBALL=LightTableLinux$(getconf LONG_BIT).tar.gz
-curl -O http://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.0/$TARBALL
+curl --fail -O http://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.0/$TARBALL
+if [ $? != 0 ] ; then echo ; echo "Cannot download binary package $TARBALL" ; echo ; fi
 tar -xzf $TARBALL
 rm $TARBALL
 cp -ar deploy/* LightTable


### PR DESCRIPTION
On 32 bit Linux system build fails wit no clear message. This patch fixes this somehow (better solution would be to run linux_deps.sh as #! script)
