### PR TITLE
Add ctrl-r mapping to redo in the default keymap

### DIFF
--- a/deploy/settings/default/default.keymap
+++ b/deploy/settings/default/default.keymap
@@ -10,6 +10,7 @@
               "pmeta-shift-enter" [:eval-editor]
               "pmeta-s" [:save]
               "pmeta-shift-s" [:save-as]
+              "ctrl-r" [:editor.redo]
               "pmeta-l" [:goto-line]
               "ctrl-." [:editor.jump-to-definition-at-cursor]
               "ctrl-," [:editor.unjump]


### PR DESCRIPTION
I think this is the least surprising behavior.
