### PR TITLE
Fix finding libudev on 64-bit openSUSE

### DIFF
--- a/platform/linux64/LightTable
+++ b/platform/linux64/LightTable
@@ -9,7 +9,7 @@ LIBUDEV_1=libudev.so.1
 add_udev_symlinks() {
   # 64-bit specific; look for libudev.so.0, and if that can't be
   # found link it to libudev.so.1
-  FOLDERS="/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /usr/lib /lib"
+  FOLDERS="/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /usr/lib64 /usr/lib /lib"
 
   for folder in $FOLDERS; do
     if [ -f "${folder}/${LIBUDEV_0}" ]; then


### PR DESCRIPTION
On 64-bit openSUSE, libudev is installed at /usr/lib64/libudev.0. This adds /usr/lib64 to the search path which prevents the following error when you try to start light table:

```
libudev.so.0 or libudev.so.1 not found in any of /lib /lib64 /lib/x86_64-linux-gnu /usr/lib /usr/lib/x86_64-linux-gnu.
```
