### PR TITLE
.zsh and .zshrc registered as shell extensions

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -254,7 +254,7 @@
                                       {:name "Sass" :exts [:sass] :mime "text/x-sass" :tags [:editor.sass]}
                                       {:name "Scala" :exts [:scala] :mime "text/x-scala" :tags [:editor.scala]}
                                       {:name "Scheme" :exts [:ss :scm :sch] :mime "text/x-scheme" :tags [:editor.scheme]}
-                                      {:name "Shell" :exts [:sh :bash :profile :bash_profile :bashrc] :mime "text/x-sh" :tags [:editor.shell]}
+                                      {:name "Shell" :exts [:sh :bash :profile :bash_profile :bashrc :zsh :zshrc] :mime "text/x-sh" :tags [:editor.shell]}
                                       {:name "Smarty" :exts [:smarty] :mime "text/x-smarty" :tags [:editor.smarty]}
                                       {:name "SPARQL" :exts [:sparql] :mime "text/x-sparql-query" :tags [:editor.sparql]}
                                       {:name "TypeScript" :exts [:ts] :mime "text/x-typescript" :tags [:editor.typescript]}


### PR DESCRIPTION
Associates .zsh and .zshrc as extensions with Shell syntax highlighting.  As a zsh user, I would find it convenient to have my config files already using shell syntax highlighting when I open them for editing instead of needing to set to syntax manually once in the editor.
