### PR TITLE
Fix minor bug in :show-docs command.

### DIFF
--- a/src/lt/objs/docs.cljs
+++ b/src/lt/objs/docs.cljs
@@ -35,8 +35,8 @@
 (cmd/command {:command :show-docs
               :desc "Docs: Open Light Table's documentation"
               :exec (fn []
-                      (let [docs (object/create ::docs)]
-                        (cmd/exec! :tabset.new)
-                        (tabs/add! docs)
-                        (tabs/active! docs)
-                        (cmd/exec! :tabs.move-next-tabset)))})
+                      (let [docs (object/create ::docs)
+                            ts (tabs/spawn-tabset)]
+                        (tabs/equalize-tabset-widths)
+                        (tabs/add! docs ts)
+                        (tabs/active! docs)))})

--- a/src/lt/objs/tabs.cljs
+++ b/src/lt/objs/tabs.cljs
@@ -223,7 +223,8 @@
   (let [ts (object/create ::tabset)
         width (- 100 (reduce + (map (comp :width deref) (@multi :tabsets))))]
     (object/merge! ts {:width width})
-    (add-tabset ts)))
+    (add-tabset ts)
+    ts))
 
 (defn equalize-tabset-widths []
   (let [tss (:tabsets @multi)


### PR DESCRIPTION
Instead of moving the new docs tab "over by one" (which breaks when there are already multiple tabsets open), keep a handle to the new tabset and add the docs tab to it.
