### PR TITLE
Fix libudev error in Linux x64 shell script

### DIFF
--- a/platform/linux64/LightTable
+++ b/platform/linux64/LightTable
@@ -9,7 +9,7 @@ LIBUDEV_1=libudev.so.1
 add_udev_symlinks() {
   # 64-bit specific; look for libudev.so.0, and if that can't be
   # found link it to libudev.so.1
-  FOLDERS="/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /usr/lib /lib"
+  FOLDERS="/usr/lib64 /lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /usr/lib /lib"
 
   for folder in $FOLDERS; do
     if [ -f "${folder}/${LIBUDEV_0}" ]; then


### PR DESCRIPTION
Light Table would not start via the provided Linux x64 shell script on openSUSE 12.3, because /usr/lib64 was missing from the libudev search path (while /lib64 was present), and on openSUSE (12.3) this is where libudev resides. This patch fixes that.
