### PR TITLE
Catch errors while walking the filesystem

### DIFF
--- a/deploy/core/node_modules/lighttable/background/walkdir2.js
+++ b/deploy/core/node_modules/lighttable/background/walkdir2.js
@@ -26,7 +26,12 @@ var walk = function(path,options){
 
   while(cur = queue.shift()) {
 
-    children = fs.readdirSync(cur);
+    try {
+      children = fs.readdirSync(cur);
+    } catch(e) {
+      console.error("Couldn't read dir " + cur);
+      continue;
+    }
 
     for(var i = 0; i < children.length; i++) {
       basename = children[i];


### PR DESCRIPTION
An EACCES during a filesystem walk stopped the walk with a bubbling error.

Fixes #1008

Since I don't have the build toolchain installed, please someone test this before merging.
