### PR TITLE
Use file path as working directory for Save As

### DIFF
--- a/src/lt/objs/opener.cljs
+++ b/src/lt/objs/opener.cljs
@@ -32,7 +32,7 @@
                        (object/raise this :open! (dom/val me))))))
 
 (defui save-input [this path]
-  [:input {:type "file" :nwsaveas path}]
+  [:input {:type "file" :nwsaveas (or path true)}]
   :change (fn []
             (this-as me
                      (when-not (empty? (dom/val me))


### PR DESCRIPTION
I've changed the behavior so that if user runs save as action on the existing file, save dialog should point to the folder containing that file. If file is new, home folder is used as a base folder for the dialog. fixes #1044
