### PR TITLE
Fix typo in plugins.cljs

### DIFF
--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -311,7 +311,7 @@
 
 (defui installed-plugin-ui [plugin]
   (let [cached (-> @manager :version-cache (get (:name plugin)))
-        update? (when chached
+        update? (when cached
                   (deploy/is-newer? (:version plugin) cached))]
     [:li {:class (if update?
                    "has-update")}


### PR DESCRIPTION
Commit 99bc667 contained a typo: "when chached" should have been "when cached".
