### PR TITLE
[Refactor] Rename active tab behavior.

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -389,7 +389,7 @@
            :lt.objs.tabs/no-anim-on-drag :lt.objs.tabs/active-tab-num
            :lt.objs.tabs/set-dragging]
   :tabset.tab [:lt.objs.tabs/on-destroy-remove
-               :lt.objs.tabs/on-active-active-tabset]
+               :lt.objs.tabs/tab-active]
   :tcp.client [:lt.objs.clients.tcp/send!]
   :theme-selector [:lt.objs.style/set-theme-on-select]
   :tree-item [:lt.objs.sidebar.workspace/rename-submit

--- a/src/lt/objs/tabs.cljs
+++ b/src/lt/objs/tabs.cljs
@@ -335,7 +335,7 @@
     (dom/add-class (object/->content ts) :active)
     true))
 
-(behavior ::on-active-active-tabset
+(behavior ::tab-active
           :triggers #{:active}
           :reaction (fn [this]
                       (activate-tabset (::tabset @this))))


### PR DESCRIPTION
Super tiny fix -- changes the name of the active tab behavior to something more friendly, as mentioned in: https://github.com/LightTable/LightTable/issues/1112
