### PR TITLE
Add helper plugin-dir function

### DIFF
--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -28,6 +28,14 @@
 (def plugins-url "http://plugins.lighttable.com")
 (def ^:dynamic *plugin-dir* nil)
 
+(defn plugin-dir [name]
+  (let [lt-plugin (files/join plugins-dir name)
+        user-plugin (files/join plugins-dir name)
+        try-dir (fn [path] (if (files/exists? path) path false))]
+    (or (try-dir lt-plugin)
+        (try-dir user-plugin))))
+
+
 (defn EOF-read [s]
   (when (and s
              (seq s))


### PR DESCRIPTION
In reference to: #1072

Since plugins are sensibly named, this helper will check for the plugin on the filesystem and return you the path if it finds it.
