### PR TITLE
Rtl direction breaks filenames formatting in the sidebar

### DIFF
--- a/deploy/core/css/structure.css
+++ b/deploy/core/css/structure.css
@@ -207,7 +207,7 @@ body { -webkit-user-select: none; }
 
 #right-bar .navigate { height:100%; overflow:auto; box-sizing:border-box; }
 #right-bar .navigate em { font-weight:normal; }
-#right-bar .navigate li { border:none; padding:5px 5px; cursor:default; overflow:hidden; direction:rtl; width:100%; box-sizing:border-box; white-space:nowrap; }
+#right-bar .navigate li { border:none; padding:5px 5px; cursor:default; overflow:hidden; width:100%; box-sizing:border-box; white-space:nowrap; }
 #right-bar .navigate li:empty { display:none; }
 #right-bar .navigate p { font-size:8pt; }
 #right-bar .navigate h2 { font-size:11pt; }


### PR DESCRIPTION
Issue was described in the mailing list https://groups.google.com/forum/?fromgroups#!topic/light-table-discussion/zp3i7jKTI2Y

Screenshots from here:
https://dl.dropboxusercontent.com/u/561580/share/lighttable%20open%20file%201.png
https://dl.dropboxusercontent.com/u/561580/share/lighttable%20open%20file%202.png

Direction css property should not be used for styling purposes, and it seems that its removal doesn't break anything.
