### PR TITLE
Save new file to workspace folder

### DIFF
--- a/src/lt/objs/opener.cljs
+++ b/src/lt/objs/opener.cljs
@@ -59,7 +59,8 @@
 (behavior ::transient-save
                   :triggers #{:save :save-as-rename!}
                   :reaction (fn [this]
-                              (let [s (save-input this (files/home))]
+                              (let [s (save-input this (or (first (:folders @workspace/current-ws))
+                                                           (files/home)))]
                                 (set! active-dialog s)
                                 (dom/trigger s :click))))
 


### PR DESCRIPTION
It might be desirable to point a transient save to the first folder in the active workspace, if available; i.e. using the first workspace folder as the location for the Save As dialog. I would say that this behavior more closely resembles a normal workflow.

In the absence of a workspace, the Save As dialog should fall back to the home folder (as it always does, currently).
