### PR TITLE
add LightTable.app and light executable to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ deploy/core/node_modules/lighttable/bootstrap.js*
 *.so
 lib
 deploy/LightTable
+deploy/LightTable.app
 deploy/credits.html
 deploy/ltbin
 deploy/nw.pak
+deploy/light

--- a/osx_deps.sh
+++ b/osx_deps.sh
@@ -1,6 +1,11 @@
 # Check if lein is installed
 lein version >/dev/null 2>&1 || { echo >&2 "Please install leiningen before running this script."; exit 1; }
 
+#remove the previously built plugins, binary, and executable
+rm -rf deploy/plugins
+rm -rf deploy/LightTable.app
+rm deploy/light
+
 #get the LightTable.app binary
 curl -O http://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.0/LightTableMac.zip
 unzip LightTableMac.zip


### PR DESCRIPTION
also remove old versions in osx build process.

I found it annoying to manually do this. It was also brought up in #1130.
