### PR TITLE
Extend basename with optional argument for extension matching

### DIFF
--- a/src/lt/objs/files.cljs
+++ b/src/lt/objs/files.cljs
@@ -214,8 +214,9 @@
 (defn absolute? [path]
   (boolean (re-seq #"^[\\\/]|([\w]+:[\\\/])" path)))
 
-(defn basename [path]
-  (.basename fpath path))
+(defn basename
+  ([path] (.basename fpath path))
+  ([path ext] (.basename fpath path ext)))
 
 (defn writable? [path]
   (let [perm (-> (.statSync fs path)


### PR DESCRIPTION
When invoked with two args, files/basename will now return filename sans extension if the second arg matches the extension; more generally, it will remove any closing substring that matches the arg, just like its Unix counterpart.

Currently, the files/basename function only wraps [path.basename](http://nodejs.org/api/path.html#path_path_basename_p_ext) without the optional extension argument.

It's a triviality, but the less js interop is unnecessarily exposed to plugin devs, the merrier we are.
