### PR TITLE
Allow custom timeout for notifos messages

### DIFF
--- a/src/lt/objs/notifos.cljs
+++ b/src/lt/objs/notifos.cljs
@@ -26,10 +26,16 @@
             (pr-str m))]
     (object/merge! statusbar/statusbar-loader (merge {:message m :class ""} opts))))
 
-(defn set-msg! [msg opts]
-  (msg* msg opts)
-  (js/clearTimeout cur-timeout)
-  (set! cur-timeout (wait standard-timeout #(msg* ""))))
+(defn set-msg!
+  ([msg]
+   (msg* msg)
+   (js/clearTimeout cur-timeout)
+   (set! cur-timeout (wait standard-timeout #(msg* ""))))
+  ([msg opts]
+   (msg* msg opts)
+   (js/clearTimeout cur-timeout)
+   (set! cur-timeout (wait (or (:timeout opts)
+                               standard-timeout) #(msg* "")))))
 
 (cmd/command {:command :reset-working
               :desc "Statusbar: Reset working indicator"


### PR DESCRIPTION
Two small changes to notifos.

The first adds a custom timeout argument to notifos/set-msg! and adds a one-argument method to the function to avoid arity errors.

The second refactors the related msg\* by making opts into an actual optional argument; no functional changes, but it eliminates a compiler warning.

Of course, feel free to cherry-pick the feature commit if you don't care for the warning pedantery.
