### PR TITLE
Suggest extension when saving new file with known syntax

### DIFF
--- a/src/lt/objs/opener.cljs
+++ b/src/lt/objs/opener.cljs
@@ -59,8 +59,13 @@
 (behavior ::transient-save
                   :triggers #{:save :save-as-rename!}
                   :reaction (fn [this]
-                              (let [s (save-input this (or (first (:folders @workspace/current-ws))
-                                                           (files/home)))]
+                              (let [path (or (first (:folders @workspace/current-ws))
+                                             (files/home))
+                                    info (:info @this)
+                                    fname (:name info)
+                                    ext (when-let [e (:exts info)]
+                                          (str "." (name (first e))))
+                                    s (save-input this (files/join path (str fname ext)))]
                                 (set! active-dialog s)
                                 (dom/trigger s :click))))
 


### PR DESCRIPTION
If the syntax of a new file has been set, the Save As dialog should suggest "untitled.extension" as filename. (The "untitled" part being removed on user input, as normal.) The first segment is not very important; "untitled" is just the name chosen by Light Table for new transient editors.

This is mostly useful when you work on a new file without knowing whether you will keep it or not, since at first you might activate the language mode by setting the syntax instead of saving. However, in the case you do decide to save it later on, it would be nice if the filename was already set to the relevant extension.
