### PR TITLE
Add native function to append to files

### DIFF
--- a/src/lt/objs/files.cljs
+++ b/src/lt/objs/files.cljs
@@ -160,6 +160,20 @@
       (when cb (cb e))
       )))
 
+(defn append [path content & [cb]]
+  (try
+    (.appendFileSync fs path content)
+    (object/raise files-obj :files.save path)
+    (when cb (cb))
+    (catch js/global.Error e
+      (object/raise files-obj :files.save.error path e)
+      (when cb (cb e))
+      )
+    (catch js/Error e
+      (object/raise files-obj :files.save.error path e)
+      (when cb (cb e))
+      )))
+
 (defn delete! [path]
   (if (dir? path)
     (.rmdirSyncRecursive wrench path)


### PR DESCRIPTION
A simple wrapper around node's .appendFileSync. It sends the same triggers as files/save, which should be reasonable enough for now.

Light Table itself doesn't have much use for it, but plugins might. (Indeed, I sent this PR because I have just added the same function to a plugin, and it seems a basic enough utility to warrant inclusion.)
