### PR TITLE
Copy platform scripts, update zip ver, add .lein-env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ deploy/logs
 .DS_Store
 deploy/core/node_modules/lighttable/bootstrap.js*
 .lein-deps-sum
+.lein-env
 .lein-plugins/
 *.so
 lib

--- a/osx_deps.sh
+++ b/osx_deps.sh
@@ -11,11 +11,13 @@ rm -rf deploy/LightTable.app
 rm deploy/light
 
 #get the LightTable.app binary
-curl -O http://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.0/LightTableMac.zip
+curl -O http://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.2/LightTableMac.zip
 unzip LightTableMac.zip
 mv LightTable/* deploy/
 rmdir LightTable/
 rm LightTableMac.zip
+
+cp -r platform/mac/* deploy/
 
 #build the core cljs of LightTable
 lein cljsbuild clean && lein cljsbuild once


### PR DESCRIPTION
A couple of small fixes for building from source.

After copying the LightTableMac.zip, copy across the platform specific scripts, else they are what was in the zip, which isn't at HEAD.

Also added .lein-env to the .gitignore which gets copied in if you use the environment lein plugin.

Mark
