### PR TITLE
Handle errors in path sourcing on OSX

### DIFF
--- a/src/lt/objs/proc.cljs
+++ b/src/lt/objs/proc.cljs
@@ -4,6 +4,7 @@
             [lt.objs.files :as files]
             [lt.objs.platform :as platform]
             [lt.objs.app :as app]
+            [lt.objs.notifos :as notifos]
             [lt.util.load :as load]
             [clojure.string :as string])
   (:require-macros [lt.macros :refer [behavior]]))
@@ -134,8 +135,12 @@
                                          (not (aget js/process.env "LTCLI")))
                                 (.exec (js/require "child_process") (str (etc-paths->PATH) (get-path-command))
                                        (fn [err out serr]
-                                         (when-not (empty? out)
-                                           (set! js/process.env.PATH out)))))))
+                                         (if-not (empty? err)
+                                           (do
+                                             (notifos/set-msg! "Failed to source PATH files. See console log for details." {:class "error"})
+                                             (.error js/console err))
+                                           (when-not (empty? out)
+                                             (set! js/process.env.PATH out))))))))
 
 (behavior ::global-path
                   :triggers #{:object.instant}


### PR DESCRIPTION
If LT stumbles during the necessary path juggling on OSX, it fails silently without notifying the user that the environment has not been properly set.

This is rare, but can happen. For example, hyphenated identifiers are documented as illegal in bash but they work normally in the terminal, while causing errors elsewhere. (I am not entirely sure of this; I have just tried with one and it works in both zsh and bash, while LT encounters an "invalid identifier" error as expected.)
