### PR TITLE
Fix leiningen detection in osx_deps.sh.

### DIFF
--- a/osx_deps.sh
+++ b/osx_deps.sh
@@ -1,6 +1,6 @@
 # Check if lein is installed
 lein version >/dev/null 2>&1 || { echo >&2 "Please install leiningen before running this script."; exit 1; }
-if [ "$(echo `lein version` | grep 'Leiningen 1.\|2.0')" ]; then 
+if [ "$(echo `lein version` | grep 'Leiningen \(1.\|2.0\)')" ]; then 
 	echo "lein version must be 2.1 or above. Do a lein upgrade first"; exit 1;
 fi
 


### PR DESCRIPTION
Current osx_deps.sh reports that Leiningen 2.2 is an old (1.x or 2.0) version. This changeset is a trivial tweak to make the version number detection a bit more robust.
