### PR TITLE
make select-all include the whole first line

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -251,7 +251,7 @@
 
 (defn select-all [e]
   (set-selection e
-                 {:line (first-line e)}
+                 {:line (first-line e) :ch 0}
                  {:line (last-line e)}))
 
 (defn clear-history [e]


### PR DESCRIPTION
(Re.: #1212) Found a way around it.
