### PR TITLE
Fix Recent Workspace Delete

### DIFF
--- a/src/lt/objs/sidebar/workspace.cljs
+++ b/src/lt/objs/sidebar/workspace.cljs
@@ -540,7 +540,7 @@
                       (when (= (:file @workspace/current-ws)
                                (files/basename (:path @this)))
                         (object/raise tree :clear!))
-                      (workspace/delete (:path @this))
+                      (files/delete! (:path @this))
                       (object/raise sidebar-workspace :recent!)))
 
 (object/object* ::recent-workspace

--- a/src/lt/objs/workspace.cljs
+++ b/src/lt/objs/workspace.cljs
@@ -160,9 +160,6 @@
   (files/save (files/join workspace-cache-path file) (pr-str (serialize @ws)))
   (object/raise ws :save))
 
-(defn delete [file]
-  (files/delete! path))
-
 (defn cached []
   (filter #(> (.indexOf % ".clj") -1) (files/full-path-ls workspace-cache-path)))
 


### PR DESCRIPTION
Remove the extra workspace delete function that is basically just
another name for the "file/delete!" function. This fixes the bug created
by trying to delete "path" when that variable doesn't exist.
