### PR TITLE
Remove obsolete compound function

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -272,10 +272,6 @@
   (.operation (->cm-ed e) func)
   e)
 
-(defn compound [e fun]
-  (.compoundChange (->cm-ed e) fun)
-  e)
-
 (defn on-click [e func]
   (let [elem (->elem e)]
     (ev/capture elem :mousedown func)


### PR DESCRIPTION
editor/compound wraps .compoundChange, a nonexistent method that was [removed in version 3](http://codemirror.net/doc/releases.html) of CodeMirror.
