### PR TITLE
Ensure open editor reflects saved file.

### DIFF
--- a/src/lt/objs/editor/file.cljs
+++ b/src/lt/objs/editor/file.cljs
@@ -13,10 +13,12 @@
           :reaction (fn [editor]
                       (let [{:keys [path]} (@editor :info)
                             pos (ed/->cursor editor)
-                            final (object/raise-reduce editor :save+ (ed/->val editor))]
-                        (ed/set-val editor final)
-                        (ed/move-cursor editor pos)
-                        (ed/center-cursor editor)
+                            orig-val (ed/->val editor)
+                            final (object/raise-reduce editor :save+ orig-val)]
+                        (when-not (= orig-val final)
+                          (ed/set-val editor final)
+                          (ed/move-cursor editor pos)
+                          (ed/center-cursor editor))
                         (doc/save path final
                                   (fn []
                                     (object/merge! editor {:dirty false


### PR DESCRIPTION
When using something like remove trailing whitespace, we can end up with
a final document being saved to disk that is different from the open
editor. This patch attempts to ensure we always reflect the editor to
reflect what was actually saved once save is over.
