### PR TITLE
Show update button below uninstall & source when there is one available

### DIFF
--- a/deploy/core/css/skins/new-dark.css
+++ b/deploy/core/css/skins/new-dark.css
@@ -279,7 +279,7 @@ input { color: var(highlight-fg); background:var(highlight-bg); }
 .plugin-manager button {background: var(highlight-bg); }
 .plugin-manager .install { box-sizing:border-box; color:var(secondary-accent-bg); background:var(secondary-accent-fg); display:inline-block; height:25px; position:absolute; right:0; top:0; width:5px; -webkit-transition:width 0.1s ease-in-out; }
 .plugin-manager .uninstall { box-sizing:border-box; color:var(tertiary-accent-bg); background:var(tertiary-accent-fg); display:inline-block; height:25px; position:absolute; right:0; top:0; width:5px; -webkit-transition:width 0.1s ease-in-out; }
-.plugin-manager .update { box-sizing:border-box; background:var(error-fg); display:inline-block; height:25px; position:absolute; right:0; top:0; width:5px; -webkit-transition:width 0.1s ease-in-out; }
+.plugin-manager .update { box-sizing:border-box; background:var(error-fg); display:inline-block; height:25px; position:absolute; right:0; top:50px; width:5px; -webkit-transition:width 0.1s ease-in-out; }
 .plugin-manager li:hover .update { width:70px; overflow:hidden; }
 .plugin-manager li:hover .update:before { color:var(error-bg); padding:4px 8px; display:inline-block; content: "update";  }
 .plugin-manager li:hover .uninstall { width:70px; overflow:hidden; }

--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -352,9 +352,9 @@
                   (deploy/is-newer? (:version plugin) cached))]
     [:li {:class (if update?
                    "has-update")}
-     (if update?
-       (update-button (assoc plugin :version cached))
-       (uninstall-button plugin))
+     (when update?
+       (update-button (assoc plugin :version cached)))
+     (uninstall-button plugin)
      (source-button plugin)
      [:h1 (:name plugin) [:span.version (:version plugin)]]
      [:h3 (:author plugin)]


### PR DESCRIPTION
This fixes Issue #1272 by making the update button appear below other 2 if available
instead of replacing the uninstall button.
