### PR TITLE
Close tab with middle / cmd + click

### DIFF
--- a/src/lt/objs/tabs.cljs
+++ b/src/lt/objs/tabs.cljs
@@ -114,8 +114,10 @@
         :obj-id (object/->id e)
         :pos pos}
    (->name e)]
-  :click (fn []
-           (active! e))
+  :click (fn [ev]
+           (if (or (= 1 (.-button ev)) (.-metaKey ev))
+             (object/raise e :close)
+             (active! e)))
   :contextmenu (fn [ev]
                  (menu! e ev)
                  (dom/prevent ev)


### PR DESCRIPTION
Allows editor tabs to be closed with either middle click or cmd + click.

Credit to @bfabry for the code.
