### PR TITLE
Handle spaces in path when opening files

### DIFF
--- a/platform/linux/LightTable
+++ b/platform/linux/LightTable
@@ -32,12 +32,17 @@ add_udev_symlinks
 
 ARGS="$@"
 
-CORRECTED=${ARGS//-/<d>}
-CORRECTED=${CORRECTED// /<s>}
+for arg in "$@"
+do
+    ESCAPED=${arg// /<ps>}
+    CORRECTED="$CORRECTED<s>$ESCAPED"
+done
+
+CORRECTED=${CORRECTED//-/<d>}
 
 if [ -t 0 ] && [ $# != 0 ]; then
   #We're in a terminal...
-  LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN "<d><d>dir=`pwd`<s>$CORRECTED" &
+  LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN "<d><d>dir=`pwd`$CORRECTED" &
 else
   #We were double clicked
   LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN &

--- a/platform/linux64/LightTable
+++ b/platform/linux64/LightTable
@@ -32,12 +32,17 @@ add_udev_symlinks
 
 ARGS="$@"
 
-CORRECTED=${ARGS//-/<d>}
-CORRECTED=${CORRECTED// /<s>}
+for arg in "$@"
+do
+    ESCAPED=${arg// /<ps>}
+    CORRECTED="$CORRECTED<s>$ESCAPED"
+done
+
+CORRECTED=${CORRECTED//-/<d>}
 
 if [ -t 0 ] && [ $# != 0 ]; then
   #We're in a terminal...
-  LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN "<d><d>dir=`pwd`<s>$CORRECTED" &
+  LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN "<d><d>dir=`pwd`$CORRECTED" &
 else
   #We were double clicked
   LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN &

--- a/platform/mac/light
+++ b/platform/mac/light
@@ -23,11 +23,17 @@ LTAPPCLI=$APP_DIR/LightTable.app/Contents/MacOS/node-webkit
 PWD=`pwd`
 ARGS="$@"
 
-CORRECTED=${ARGS//-/<d>}
-CORRECTED=${CORRECTED// /<s>}
+for arg in "$@"
+do
+    ESCAPED=${arg// /<ps>}
+    CORRECTED="$CORRECTED<s>$ESCAPED"
+done
+
+CORRECTED=${CORRECTED//-/<d>}
+
 
 if [ $# != 0 ]; then
-    LTCLI=true $LTAPPCLI "<d><d>dir=$PWD<s>$CORRECTED" &
+    LTCLI=true $LTAPPCLI "<d><d>dir=$PWD$CORRECTED" &
 else
     LTCLI=true $LTAPPCLI &
 fi

--- a/src/lt/objs/cli.cljs
+++ b/src/lt/objs/cli.cljs
@@ -10,11 +10,17 @@
   (:require-macros [lt.macros :refer [behavior]]))
 
 (defn rebuild-argv [argstr]
-  (-> (subs argstr (.indexOf argstr "<d><d>dir"))
-      (string/replace "<d>" "-")
-      (string/replace "<s>" " ")
-      (string/split " ")
-      (to-array)))
+  (let [likely-args (count (re-seq #"--" argstr))
+        threshold 4
+        dir-arg "<d><d>dir"
+        i (.indexOf argstr dir-arg)]
+    (if (or (>= i 0) (>= likely-args threshold))
+      (to-array (map #(string/replace % "<ps>" " ")
+                     (-> (subs argstr index)
+                         (string/replace "<d>" "-")
+                         (string/replace "<s>" " ")
+                         (string/split " "))))
+      (to-array [argstr]))))
 
 (defn parse-args [argv]
   (-> (.. (node-module "optimist")


### PR DESCRIPTION
A quick patch for #1292, tested on OSX and Ubuntu 64bit. The solution is rather hacky, but further review would be needed regardless, since I have no way to verify this change on Windows.

You might notice the additional predicate in rebuild-argv. It is an ad-hoc check for node-webkit arguments, required on OS X because light.sh seemingly launches LT twice; this check is unsound, albeit not significantly more so than parsing for `<d><d>dir` already was.
