### PR TITLE
Prevent opening multiple console tabs.

### DIFF
--- a/src/lt/objs/console.cljs
+++ b/src/lt/objs/console.cljs
@@ -182,9 +182,10 @@
 (cmd/command {:command :console-tab
               :desc "Console: Open the console in a tab"
               :exec (fn []
-                      (object/merge! console {:current-ui :tab})
-                      (tabs/add! console)
-                      )})
+                      (when (not= :tab (:current-ui @console)) ; Running the command when tab is already opened in a tab was creating another new tab each time.
+                        (object/merge! console {:current-ui :tab})
+                        (tabs/add! console)
+                      ))})
 
 (cmd/command {:command :toggle-console
               :desc "Console: Toggle console"


### PR DESCRIPTION
Running the :console-tab command multiple times created a new tab each time, and appended the console to the last one.

Also, when the console is open on the bottombar, and you run the :console-tab command, the bottombar tabset doesn't shrink. I wanted to fix that but since I didn't know the prefered way to tell the bottombar to update its size, instead of setting it's height manually from console.cljs, I decided to leave it. I had a similar issue with a sublime, where I needed hide or show but only toggle was available. It would be nice to have hide and show for every toggle, it's very handy when binding key combinations to multiple commands. (e.g. "ctrl-3" [:show-sidebar :hide-commands :hide-console])
