### PR TITLE
Add a `trigger` to args of an `:object.behavior.time` event.

### DIFF
--- a/src/lt/object.cljs
+++ b/src/lt/object.cljs
@@ -179,7 +179,7 @@
       (binding [*behavior-meta* meta]
         (apply func obj args))
       (when-not (= trigger :object.behavior.time)
-        (raise obj :object.behavior.time r time)))
+        (raise obj :object.behavior.time r time trigger)))
       (catch js/Error e
         (safe-report-error (str "Invalid behavior: " (-> (->behavior r) :name)))
         (safe-report-error e)
@@ -376,6 +376,8 @@
 
 (behavior ::report-time
            :triggers #{:object.behavior.time}
-           :reaction (fn [this beh time]
+           :reaction (fn [this beh time trigger]
                        (when js/lt.objs.console
-                         (js/lt.objs.console.log (str beh " took " time "ms")))))
+                         (js/lt.objs.console.log (str beh " triggered by "
+                                                      trigger " took "
+                                                      time "ms")))))


### PR DESCRIPTION
I have exposed `trigger` on `:object.behavior.time` event as suggested on mailing list.
I was not sure how to go about `raise-reduce` cause I was not sure what the expected behaiov
is supposed to be:
- Is it supposed to return result of last application ?
- Does error in one of the behaviors supposed to break a loop and propagate errors ?
