### PR TITLE
Add ellipsis to truncated results

### DIFF
--- a/src/lt/objs/eval.cljs
+++ b/src/lt/objs/eval.cljs
@@ -168,7 +168,7 @@
                 nl
                 (:trunc-length opts 50))]
       (if (> (count r) len)
-        (subs r 0 len)
+        (str (subs r 0 len)  " …")
         r))))
 
 (defui ->inline-res [this info]


### PR DESCRIPTION
In order to make the truncation of inline results more evident, an ellipsis is appended to the widget.

Closes #1334.
