### PR TITLE
Add setting for number of files indexed by the navigator

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -307,7 +307,8 @@
   :navigate.selector [:lt.objs.sidebar.navigate/escape!
                       :lt.objs.sidebar.navigate/pop-transient-on-select
                       :lt.objs.sidebar.navigate/open-on-select]
-  :navigator [:lt.objs.sidebar.navigate/focus! :lt.objs.sidebar.navigate/focus-on-show :lt.objs.sidebar.navigate/workspace-files]
+  :navigator [:lt.objs.sidebar.navigate/focus! :lt.objs.sidebar.navigate/focus-on-show :lt.objs.sidebar.navigate/workspace-files
+              (:lt.objs.sidebar.navigate/set-file-limit 8000)]
   :object [:lt.objs.clients/on-destroy-remove-cb]
   :opener [:lt.objs.opener/open-from-info :lt.objs.opener/open-transient-editor
            :lt.objs.opener/open-standard-editor


### PR DESCRIPTION
User setting for the maximum number of files that the navigator will index for each top workspace folder.
It may be used by adding `:navigator [(:lt.objs.sidebar.navigate/set-file-limit n)]` to a plus behavior map.

Closes #1335. 
