### PR TITLE
focussing url bar highlights url

### DIFF
--- a/src/lt/objs/browser.cljs
+++ b/src/lt/objs/browser.cljs
@@ -168,7 +168,9 @@
 (behavior ::url-focus!
                   :triggers #{:url.focus!}
                   :reaction (fn [this]
-                              (dom/focus (dom/$ :input (object/->content this)))))
+                              (let [url-input (dom/$ :input (object/->content this))]
+                                (dom/focus url-input)
+                                (.select url-input))))
 
 (behavior ::focus!
                   :triggers #{:focus!}


### PR DESCRIPTION
Small change to URL bar behaviour.

Before, hitting ctrl-l in a browser window would focus the url-bar, but not select the text inside.
This change causes the text to be highlighted, so it's more consistent with how dedicated browsers work.
