### PR TITLE
Add function to associate keyvals in objects

### DIFF
--- a/src/lt/object.cljs
+++ b/src/lt/object.cljs
@@ -220,6 +220,11 @@
 (defn update! [obj & r]
   (swap! obj #(apply update-in % r)))
 
+(defn assoc-in! [obj k v]
+  (when (and k (not (sequential? k)))
+    (throw (js/Error. (str "Associate requires a sequence of keys: " k))))
+  (swap! obj #(assoc-in % k v)))
+
 (defn ->id [obj]
   (if (deref? obj)
     (::id @obj)


### PR DESCRIPTION
Defines `lt.object/associate!`, a new function that calls `assoc-in` on the state of an LT object. (Nothing too important; just a small addition for caller convenience.)

Functionally, it is a subset of `object/merge!`, but it allows to update or create deeply nested key-value pairs in a more readable fashion when the pre-existing state is irrelevant. E.g.:

``` clojure
(object/associate! obj [:deeply :nested :key :value] 1)
```

rather than

``` clojure
(object/merge! obj {:deeply {:nested {:key {:value 1}}}})
```

or

``` clojure
(object/update! obj [:deeply :nested :key] conj {:value 1})
```
