### PR TITLE
Adding a set-line function to editor.cljs

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -289,6 +289,9 @@
 (defn line [e l]
   (.getLine (->cm-ed e) l))
 
+(defn set-line [e l text]
+  (.setLine (->cm-ed e) l text))
+
 (defn first-line [e]
   (.firstLine (->cm-ed e)))
 


### PR DESCRIPTION
I need this for a plugin that I am writing. I am creating a refactoring plugin which needs to place text at specified lines in the editor.
