### PR TITLE
Add context logging

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -140,6 +140,7 @@
   :console [:lt.objs.console/on-close
             :lt.objs.menu/menu!
             :lt.objs.console/menu+]
+  :context [:lt.objs.context/log]
   :document [:lt.objs.document/try-close-root-document :lt.objs.document/close-root-document]
   :document.linked [:lt.objs.document/close-linked-document]
   :docs [:lt.objs.docs/on-close-destroy]


### PR DESCRIPTION
As discussed in #1362, here is a PR that adds a simple history of context changes.

The few pieces of dead code have been cleaned up, `ctx-obj` has been repurposed, `in!` and `out!` have been adapted.
The ring buffer is implemented as a thin wrapper around native cljs queues. (Judging from the clj JIRA/GitHub/mailing list, their implementation is stable; they just lack a reader literal.)

Closes #1362.

A note:
For the purpose of history, context changes that are always executed together should likely be considered a single atomic change, and logged as one entry. However, this is not currently possible in a reasonably concise way, because `in!` and `out!` are separate. (This is also part of the reason why the idea of keeping two separate logs for `in` and `out` seemed better than simply recording the new context itself: functions that both add to and remove from the context generate spurious entries describing contexts that were never really there as far as any other object in LT is concerned. The pollution generated by these entries would significantly diminish the utility of the log.)
We might want to improve this in the future, as we develop introspection tools.
