### PR TITLE
allow options to be set for line commenting

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -161,6 +161,7 @@
            :lt.plugins.auto-paren/close-pair :lt.objs.editor.pool/track-active
            :lt.objs.editor.pool/ed-close :lt.objs.editor/menu!
            :lt.objs.editor.pool/warn-on-active :lt.objs.editor/refresh!
+           (:lt.objs.editor.pool/line-comment-options {})
            :lt.plugins.auto-paren/repeat-pair
            :lt.plugins.auto-complete/async-hint-tokens
            :lt.objs.editor/copy-paste-menu+
@@ -221,8 +222,7 @@
   :editor.pool [:lt.objs.editor.pool/add-tab-settings
                 :lt.objs.editor.pool/options-changed
                 :lt.objs.editor.pool/line-numbers-changed
-                :lt.objs.editor.pool/theme-changed
-                (:lt.objs.editor.pool/line-comment-options {})]
+                :lt.objs.editor.pool/theme-changed]
   :editor.read-only [:lt.objs.editor/read-only]
   :editor.structural [:lt.plugins.struct/rem-on-close]
   :editor.transient [:lt.objs.editor.file/dirty-on-change

--- a/src/lt/objs/editor/pool.cljs
+++ b/src/lt/objs/editor/pool.cljs
@@ -249,8 +249,6 @@
 ;;****************************************************
 
 ;; See https://github.com/marijnh/CodeMirror/blob/master/addon/comment/comment.js for options
-(def line-comment-options {})
-
 (behavior ::line-comment-options
           :triggers #{:object.instant}
           :type :user
@@ -258,7 +256,7 @@
           :params [{:label "map"
                     :example "{:indent true}"}]
           :reaction (fn [this options]
-                      (set! line-comment-options options)))
+                      (object/merge! this {::comment-options options})))
 
 (cmd/command {:command :comment-selection
               :desc "Editor: Comment line(s)"
@@ -266,8 +264,8 @@
                       (when-let [cur (last-active)]
                         (let [cursor (editor/->cursor cur "start")]
                           (if (editor/selection? cur)
-                            (editor/line-comment cur cursor (editor/->cursor cur "end") line-comment-options)
-                            (editor/line-comment cur cursor cursor line-comment-options)))))})
+                            (editor/line-comment cur cursor (editor/->cursor cur "end") (::comment-options @cur))
+                            (editor/line-comment cur cursor cursor (::comment-options @cur))))))})
 
 (cmd/command {:command :uncomment-selection
               :desc "Editor: Uncomment line(s)"
@@ -287,7 +285,7 @@
                                             [cursor (editor/->cursor cur "end")]
                                             [cursor cursor])]
                           (when-not (editor/uncomment cur start end)
-                            (editor/line-comment cur cursor (editor/->cursor cur "end") line-comment-options)))))})
+                            (editor/line-comment cur cursor (editor/->cursor cur "end") (::comment-options @cur))))))})
 
 (cmd/command {:command :indent-selection
               :desc "Editor: Indent line(s)"


### PR DESCRIPTION
This allows line commenting to take [addon options](https://github.com/marijnh/CodeMirror/blob/master/addon/comment/comment.js). Specifically, I wanted to have [my comments indented](https://github.com/cldwalker/ltfiles/blob/eb65c4a3f6d7010caabf60119d4e12306db3dd4f/src/lt/plugins/ltfiles/vim.cljs#L36-L47) while in clojure. I could also add a default of `{:indent true}` to the Clojure plugin if desired.
