### PR TITLE
fix typo in catch argument

### DIFF
--- a/src/lt/objs/eval.cljs
+++ b/src/lt/objs/eval.cljs
@@ -144,9 +144,7 @@
 (defn try-read [r]
   (try
     (reader/read-string r)
-    (catch js/Error e
-      r)
-    (catch js/global.Error e
+    (catch :default e
       r)))
 
 ;;****************************************************


### PR DESCRIPTION
I noticed this while trying to use it from a plugin. I don't see it used anywhere so I could remove it also if desired
