### PR TITLE
add platform-friendly copy and paste

### DIFF
--- a/src/lt/objs/platform.cljs
+++ b/src/lt/objs/platform.cljs
@@ -13,6 +13,16 @@
 (defn open [path]
   (.Shell.openExternal (js/require "nw.gui") path))
 
+(defn copy
+  "Copies given text to platform's clipboard"
+  [text]
+  (.set (.Clipboard.get (js/require "nw.gui")) text "text"))
+
+(defn paste
+  "Returns text of last copy to platform's clipboard"
+  []
+  (.get (.Clipboard.get (js/require "nw.gui")) "text"))
+
 (def platform (normalize (.-platform js/process)))
 
 (defn mac? []


### PR DESCRIPTION
While writing the [gitbeam plugin](https://github.com/cldwalker/gitbeam), I was unaware this was possible with node-webkit. Hopefully, this makes it easier to use the clipboard, for end-users or [plugins](https://github.com/cldwalker/gitbeam/blob/ae630679b4fded97cc91375ea1f3babc419835b1/src/lt/plugins/gitbeam/util.cljs#L80-L85). I noticed editor.cljs has a few references to clipboard. I can update those to use these fns if desired.
