### PR TITLE
require command keys to avoid missing keys breaking commandbar

### DIFF
--- a/src/lt/objs/command.cljs
+++ b/src/lt/objs/command.cljs
@@ -3,7 +3,11 @@
 
 (declare manager)
 
+(def required-keys #{:command :desc :exec})
+
 (defn command [cmd]
+  (assert (every? cmd required-keys)
+          (str "Command doesn't have required keys: " required-keys))
   (object/update! manager [:commands] assoc (:command cmd) cmd)
   (when (:options cmd)
     (object/add-tags (:options cmd) [:command.options]))


### PR DESCRIPTION
While writing commands, I accidently defined a command that broke the commandbar:

``` clj
(cmd/command {:command :ltfiles.woah
              :exec (constantly false)})
```

After eval-ing this, the commandbar was unusable and each keypress resulted in this error:

```
"Invalid behavior: :lt.objs.sidebar.command/update-lis"
TypeError: Cannot call method 'toLowerCase' of null
    at fastScore (/Applications/LightTable.app/Contents/Resources/app.nw/core/node_modules/lighttable/util/fuzzy.js:101:13)
    at eval (file:///Applications/LightTable.app/Contents/Resources/app.nw/core/node_modules/lighttable/bootstrap.js:25119:34)
    at Array.map (native)
    at lt.objs.sidebar.command.indexed_results (file:///Applications/LightTable.app/Contents/Resources/app.nw/core/node_modules/lighttable/bootstrap.js:25138:10)
    at Function.lt.objs.sidebar.command.__BEH__update_lis (file:///Applications/LightTable.app/Contents/Resources/app.nw/core/node_modules/lighttable/bootstrap.js:25075:177)
    at c (file:///Applications/LightTable.app/Contents/Resources/app.nw/core/node_modules/lighttable/bootstrap.js:6196:14)
    at a (file:///Applications/LightTable.app/Contents/Resources/app.nw/core/node_modules/lighttable/bootstrap.js:6236:18)
    at lt.object.raise_STAR_ (file:///Applications/LightTable.app/Contents/Resources/app.nw/core/node_modules/lighttable/bootstrap.js:20533:74)
    at a (file:///Applications/LightTable.app/Contents/Resources/app.nw/core/node_modules/lighttable/bootstrap.js:20566:34)
    at b (file:///Applications/LightTable.app/Contents/Resources/app.nw/core/node_modules/lighttable/bootstrap.js:20570:
```

I figured we should prevent this from happening to lazy users (like me) or unknowing plugin authors.
