### PR TITLE
URI encode sourceURL of js files

### DIFF
--- a/src/lt/util/load.cljs
+++ b/src/lt/util/load.cljs
@@ -32,7 +32,7 @@
 (defn- prep [code file]
   (-> code
       (abs-source-mapping-url file)
-      (str "\n\n//# sourceURL=" file)))
+      (str "\n\n//# sourceURL="  (js/encodeURI file))))
 
 (defn js
   ([file] (js file false))


### PR DESCRIPTION
vim.js from the Vim plugin couldn't be found by the dev-inspector and this fixed things. I assume it had to do with fixing the spaces in the path. E.g. previously it was "/Users/me/Application Settings/..."
