### PR TITLE
Ignore case when sorting installed plugins

### DIFF
--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -520,7 +520,7 @@
                       (object/merge! app/app {::plugins (available-plugins)})
                       (let [ul (dom/$ :.plugins (object/->content this))]
                         (dom/empty ul)
-                        (dom/append ul (dom/fragment (map installed-plugin-ui (->> @app/app ::plugins vals (sort-by :name))))))))
+                        (dom/append ul (dom/fragment (map installed-plugin-ui (->> @app/app ::plugins vals (sort-by #(.toUpperCase (:name %))))))))))
 
 (behavior ::on-close
           :triggers #{:close}


### PR DESCRIPTION
The installed plugin list puts plugins that start with a lower case letter at the bottom of the list. This ignores the case when rendering.

Before
![screen shot 2014-04-01 at 8 32 56 pm](https://cloud.githubusercontent.com/assets/185091/2577558/3ff6af2c-b981-11e3-9ac6-c3f309698ec2.png)

After
![screen shot 2014-04-01 at 8 33 34 pm](https://cloud.githubusercontent.com/assets/185091/2577552/3279a1e2-b981-11e3-90d0-ca3e6bd4aeb9.png)
