### PR TITLE
searcher's search! behavior should use argument it's given

### DIFF
--- a/src/lt/objs/search.cljs
+++ b/src/lt/objs/search.cljs
@@ -116,9 +116,9 @@
 
 (behavior ::search!
           :triggers #{:search!}
-          :reaction (fn [this]
+          :reaction (fn [this search-info]
                       (object/raise this :clear!)
-                      (let [info (->search-info this)]
+                      (let [info (or search-info (->search-info this))]
                         (when-not (empty? (:search info))
                           (object/merge! this info)
                           (notifos/working "Searching workspace...")


### PR DESCRIPTION
I tried passing an argument to the [:searcher.search command](https://github.com/LightTable/LightTable/blob/master/src/lt/objs/search.cljs#L244-L246) for [a plugin I'm working on](https://github.com/cldwalker/ltfiles/blob/8f6f90544d1ff047ed57a8a04d69d0548c2f9973/src/lt/plugins/ltfiles/developer.cljs#L57-L63). The search! behavior doesn't use what it's passed contrary the intent of the command. I left `->search-info` in the behavior for backwards compatibility.
