### PR TITLE
Add add-gutter / remove-gutter to editor

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -373,29 +373,29 @@
 
 (defn add-gutter [e class-name width]
   (let [gutter-classes (set (conj (js->clj (option e "gutters")) class-name))
-        gutter-div (dom/$ :div.CodeMirror-gutters (object/->content e))
-        gutter-divs (dom/$$ :div.CodeMirror-gutter gutter-div)
-        current-widths (reduce (fn [res gutter]
-                                 (let [gutter-class (clojure.string/replace-first (dom/attr gutter "class") "CodeMirror-gutter " "")]
-                                   (assoc res gutter-class (dom/width gutter)))
-                                 ) {} gutter-divs)
+        current-widths (gutter-widths e)
         new-gutter-widths (assoc current-widths class-name width)]
-    (operation e (fn[]
-                   (set-options e {:gutters (clj->js gutter-classes)})
-                   (doseq [[k v] new-gutter-widths]
-                     (dom/set-css (dom/$ (str "div." k) gutter-div) {"width" (str v "px")}))))))
+    (update-gutters e gutter-classes new-gutter-widths)))
 
 (defn remove-gutter [e class-name]
   (let [gutter-classes (remove #{class-name} (js->clj (option e "gutters")))
-        gutter-div (dom/$ :div.CodeMirror-gutters (object/->content e))
+        current-widths (gutter-widths e)]
+    (update-gutters e gutter-classes current-widths)))
+
+(defn gutter-widths [e]
+  (let [gutter-div (dom/$ :div.CodeMirror-gutters (object/->content e))
         gutter-divs (dom/$$ :div.CodeMirror-gutter gutter-div)
         current-widths (reduce (fn [res gutter]
                                  (let [gutter-class (clojure.string/replace-first (dom/attr gutter "class") "CodeMirror-gutter " "")]
                                    (assoc res gutter-class (dom/width gutter)))
                                  ) {} gutter-divs)]
+    current-widths))
+
+(defn update-gutters [e class-names class-widths]
+  (let [gutter-div (dom/$ :div.CodeMirror-gutters (object/->content e))]
     (operation e (fn[]
-                   (set-options e {:gutters (clj->js gutter-classes)})
-                   (doseq [[k v] new-gutter-widths]
+                   (set-options e {:gutters (clj->js class-names)})
+                   (doseq [[k v] class-widths]
                      (if-let [gutter (dom/$ (str "div." k) gutter-div)]
                        (dom/set-css gutter {"width" (str v "px")})))))))
 


### PR DESCRIPTION
Adding gutters directly to the editor using CodeMirror affects any other gutters that were added dynamically because the container divs are recreated each time a new gutter is added, removing style information and making gutters collapse over each other. One fix for this is to add a css file that defines the width for the gutter, which is fine if you do not want dynamically sized gutters like the gitlight and GBlame plugins.
This adds an api for plugins to use to add gutters to the right side of existing gutters and remove an existing gutter. Gutters can also be managed via `update-gutters`.

/cc @mrogalski @bfabry
