### PR TITLE
copy inline result from its menu

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -306,7 +306,8 @@
                   :lt.objs.eval/expand-on-click :lt.objs.eval/clear-mark
                   :lt.objs.eval/move-mark :lt.objs.eval/changed
                   :lt.objs.eval/update!
-                  :lt.objs.eval/destroy-on-cleared]
+                  :lt.objs.eval/destroy-on-cleared
+                  :lt.objs.eval/copy-result]
   :inline.underline-result [:lt.objs.eval/result-menu! :lt.objs.eval/ex-clear :lt.objs.eval/destroy-on-clear]
   :inline.watch [:lt.plugins.watches/clear!]
   :inspector.object [:lt.objs.clients.devtools/clear-inspector-object]

--- a/src/lt/objs/eval.cljs
+++ b/src/lt/objs/eval.cljs
@@ -14,7 +14,8 @@
             [crate.binding :refer [bound]]
             [lt.objs.console :as console]
             [lt.util.dom :as dom]
-            [clojure.string :as string])
+            [clojure.string :as string]
+            [lt.objs.platform :as platform])
   (:require-macros [lt.macros :refer [behavior defui]]))
 
 (defui button [label & [cb]]
@@ -194,7 +195,9 @@
           :triggers #{:menu!}
           :reaction (fn [this ev]
                       (-> (menu/menu [{:label "Remove result"
-                                       :click (fn [] (object/raise this :clear!))}])
+                                       :click (fn [] (object/raise this :clear!))}
+                                      {:label "Copy result"
+                                       :click (fn [] (object/raise this :copy))}])
                           (menu/show-menu (.-clientX ev) (.-clientY ev)))
                       (dom/prevent ev)
                       (dom/stop-propagation ev)))
@@ -227,6 +230,11 @@
                         (.clear (:mark @this))
                         (object/raise this :clear)
                         (object/raise this :cleared))))
+
+(behavior ::copy-result
+          :triggers #{:copy}
+          :reaction (fn [this]
+                      (platform/copy (:result @this))))
 
 (behavior ::changed
           :triggers #{:changed}


### PR DESCRIPTION
For large inline results, I sometimes want to view/search all of it which copying enables. I've done this enough [that I have a keystroke](https://github.com/cldwalker/ltfiles/blob/6ca79bb00f152f911f6abdff3b97bee42a9c5158/src/lt/plugins/ltfiles/inline-result.cljs#L30-L32) that works seamlessly 90% of the time. I figure having this in the menu would be useful to others and to me in cases where my keystroke doesn't work (i.e. non-paredit scenarios).
