### PR TITLE
Remove windowsVerbatimArguments option

### DIFF
--- a/src/lt/objs/proc.cljs
+++ b/src/lt/objs/proc.cljs
@@ -48,8 +48,7 @@
   (let [proc (spawn command
                     (when (seq args) (clj->js args))
                     (js-obj "cwd" cwd?
-                            "env" (merge-env env)
-                            "windowsVerbatimArguments" (when (= js/process.platform "win32") true)))]
+                            "env" (merge-env env)))]
     (add! proc)
     (.on proc "exit" (partial rem! proc))
     (.on proc "error" #(when @obj


### PR DESCRIPTION
This is an undocumented internal option which introduces several issues on windows (see joyent/node#7441).

If anything depends on this, `spawn-simple*` could take it as an option – but it shouldn't be the default.
