### PR TITLE
Add multiple fonts support

### DIFF
--- a/src/lt/objs/style.cljs
+++ b/src/lt/objs/style.cljs
@@ -12,7 +12,8 @@
             [lt.util.dom :as dom]
             [lt.util.load :as load]
             [crate.binding :refer [bound -value subatom]]
-            [crate.compiler :refer [dom-attr]])
+            [crate.compiler :refer [dom-attr]]
+            [clojure.string :as string])
   (:require-macros [lt.macros :refer [behavior defui]]))
 
 (defn css-expr [k v]
@@ -21,12 +22,17 @@
 (defn selector [sel & body]
   (str sel " { " (apply str body) " }"))
 
+(defn str-font-family [x]
+  (if (vector? x)
+    (string/join ", " (map pr-str x))
+    (pr-str x)))
+
 (defn ->css [settings]
   (selector ".CodeMirror"
             (when (:line-height settings)
               (css-expr :line-height (str (:line-height settings) "em")))
             (when (:font-family settings)
-              (css-expr :font-family (pr-str (:font-family settings))))
+              (css-expr :font-family (str-font-family (:font-family settings))))
             (when (:font-size settings)
               (css-expr :font-size (str (:font-size settings) "pt")))))
 


### PR DESCRIPTION
I would like to use different fonts for different languages characters (e.g.
English letter and Japanese kanji).

This pull request enables Light Table font-family setting to accept a string
or a vector of strings.

``` clojure
{:+ {:editor [(:lt.objs.style/font-settings
               "Menlo"
               "10"
               "1.2")]}}
```

``` clojure
{:+ {:editor [(:lt.objs.style/font-settings
               ["Menlo" "Hiragino Maru Gothic ProN"]
               "10"
               "1.2")]}}
```
