### PR TITLE
tweak rem! function to remove tabset if there are no tabs

### DIFF
--- a/src/lt/objs/tabs.cljs
+++ b/src/lt/objs/tabs.cljs
@@ -283,8 +283,9 @@
         (object/raise cur-tabset :tab idx)
         (when (not= aidx (->index active))
           (object/merge! cur-tabset {:active-obj nil})
-          (active! active))
-        ))))
+          (active! active)))
+      (if (empty? (:objs @cur-tabset))
+        (rem-tabset cur-tabset nil)))))
 
 (defn add!
   ([obj] (add! obj nil))


### PR DESCRIPTION
Close tabset when
- Tab is closed and there are no tabs in the tabset.  
- Tab is moved to another tabset and there are no tabs in source tabset.
