### PR TITLE
Add proxy support for plugins download.

### DIFF
--- a/src/lt/objs/deploy.cljs
+++ b/src/lt/objs/deploy.cljs
@@ -75,6 +75,8 @@
   (let [options (js-obj "url" from
                         "headers" (js-obj "User-Agent" "Light Table"))
         out (.createWriteStream fs to)]
+    (when-let [proxy (or (-> js/process .-env .-http_proxy) (-> js/process .-env .-https_proxy))]
+      (set! (.-proxy options) proxy))
     (.pipe (request options cb) out)))
 
 (defn download-zip [ver cb]


### PR DESCRIPTION
This is a fix for plugins' proxy support, it reads proxy settings from the environment variables "http_proxy" or "https_proxy". You can refer to the issue #1094.
