### PR TITLE
Fix regression in solarized theme introduced by  #1384

### DIFF
--- a/deploy/core/css/themes/solarized.css
+++ b/deploy/core/css/themes/solarized.css
@@ -90,17 +90,17 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
 .cm-s-solarized .cm-strong { color: #eee; }
 
 .cm-s-solarized .CodeMirror-focused .CodeMirror-selected {
-  background: #386774;
+  background: #073642;
   color: inherit;
 }
 
 .cm-s-solarized ::selection {
-  background: #386774;
+  background: #073642;
   color: inherit;
 }
 
 .cm-s-solarized .CodeMirror-selected {
-  background: #586e75;
+  background: #073642;
 }
 
 /* Editor styling */
@@ -154,7 +154,7 @@ view-port
 */
 .cm-s-solarized .CodeMirror-activeline,
 .cm-s-solarized .activeline {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.02);
 }
 /*
 View-port and gutter both get little noise background to give it a real feel.


### PR DESCRIPTION
This for  #1261 that does not require adding more colors to the solarized color pallet. This fix uses selection color similar to how other editors (for example textmate do).
![screen shot 2014-05-19 at 14 55 53](https://cloud.githubusercontent.com/assets/21236/3020552/d901d832-dfa0-11e3-88fc-6aeb778341d7.png)
![screen shot 2014-05-19 at 14 56 10](https://cloud.githubusercontent.com/assets/21236/3020553/d902e146-dfa0-11e3-81bc-b6817f5b2b3f.png)
