### PR TITLE
Update editor/set-line to CodeMirror 4 API

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -290,7 +290,11 @@
   (.getLine (->cm-ed e) l))
 
 (defn set-line [e l text]
-  (.setLine (->cm-ed e) l text))
+  (let [length (line-length e l)]
+    (replace e
+             {:line l :ch 0}
+             {:line l :ch length}
+             text)))
 
 (defn first-line [e]
   (.firstLine (->cm-ed e)))


### PR DESCRIPTION
As noted in #1359, `lt.objs.editor/set-line` currently wraps the CodeMirror method `.setLine`, which has been ~~deprecated~~ dropped as of version 4.

This patch provides equivalent functionality via `editor/replace`.
