### PR TITLE
Make editor/line-count take a LT editor

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -195,7 +195,7 @@
   (.getRange (->cm-ed e) (clj->js from) (clj->js to)))
 
 (defn line-count [e]
-  (.lineCount e))
+  (.lineCount (->cm-ed e)))
 
 (defn insert-at-cursor [ed s]
   (replace (->cm-ed ed) (->cursor ed) s)


### PR DESCRIPTION
For consistency with other endpoints of the editor API, `lt.objs.editor/line-count` should likely accept a native Light Table editor instead of a CodeMirror instance.
