### PR TITLE
Add support for connecting to browsers via XHR

### DIFF
--- a/deploy/core/node_modules/lighttable/ws.js
+++ b/deploy/core/node_modules/lighttable/ws.js
@@ -43,7 +43,9 @@
   }
 
   var thisScript = document.getElementById("lt_ws");
-  var parts = thisScript.src.split(":");
+  var useXhr = thisScript.hasAttribute("data-xhr-src");
+  var src = useXhr ? thisScript.getAttribute("data-xhr-src") : thisScript.src;
+  var parts = src.split(":");
   if(parts.length > 2) {
     var host = parts[0]+":"+parts[1];
     var port = parts[2].split("/")[0];
@@ -149,22 +151,50 @@
     };
   }
 
-  function loadScript(sScriptSrc,callbackfunction) {
-    var oHead = document.getElementsByTagName('head')[0];
-    var oScript = document.createElement('script');
-    oScript.setAttribute('src',sScriptSrc);
-    oScript.setAttribute('type','text/javascript');
-    var loadFunction = function() {
-      if (this.readyState == 'complete' || this.readyState == 'loaded') {
+  function addScript(args, callbackfunction) {
+    var isDone = false;
+    var done = function () {
+      if (!isDone) {
+        isDone = true;
         callbackfunction();
       }
     };
+    var oHead = document.getElementsByTagName('head')[0];
+    var oScript = document.createElement('script');
+    if (args.srcUrl) {
+      oScript.setAttribute('src',args.srcUrl);
+    } else {
+      oScript.textContent = args.code;
+    }
+    oScript.setAttribute('type','text/javascript');
+    var loadFunction = function() {
+      if (this.readyState == 'complete' || this.readyState == 'loaded') {
+        done();
+      }
+    };
     oScript.onreadystatechange = loadFunction;
-    oScript.onload = callbackfunction;
+    oScript.onload = done;
     oHead.appendChild(oScript);
   }
 
+  function loadScriptWithSrc(sScriptSrc,callbackfunction) {
+    addScript({ srcUrl: sScriptSrc }, callbackfunction);
+  }
 
+  function loadScriptWithXhr(sScriptSrc,callbackfunction) {
+    var request = new XMLHttpRequest();
+    var loadFunction = function () {
+      if (request.readyState === 4) {
+        request.onreadystatechange = null;
+        addScript({ code: request.responseText }, callbackfunction);
+      }
+    };
+    request.onreadystatechange = loadFunction;
+    request.open("get", sScriptSrc, true);
+    request.send();
+  }
+
+  var loadScript = useXhr ? loadScriptWithXhr : loadScriptWithSrc;
 
   if(window.io) {
     init();


### PR DESCRIPTION
Some HTML-based app environments (e.g. Windows Web Apps) do not support
cross-domain script inclusion but they do support cross-domain XHRs. This
change builds support into LightTable to be able to connect to such app
environments to evaluate HTML, JavaScript, and CSS.
