### PR TITLE
ibdknox.css: fix tab coloring

### DIFF
--- a/deploy/core/css/themes/ibdknox.css
+++ b/deploy/core/css/themes/ibdknox.css
@@ -3,7 +3,7 @@
 #multi.theme-ibdknox .list .dirty { color:#C7E6FF; }
 #multi.theme-ibdknox .tabset .list .active { color:#aaa; }
 #multi.theme-ibdknox .tabset.active .list .active { color:#f4f4f4; }
-#multi.theme-ibdknox .tabset.active .list .dirty { color:#C7E6FF; }
+#multi.theme-ibdknox .tabset .list .dirty { color:#C7E6FF; }
 
 .cm-s-ibdknox { background: #202020; color:#ccc; }
 


### PR DESCRIPTION
To see what this commit does do following:
1. Set editor theme to "ibdknox".
2. In new-dark.css change var-highlight-fg to #0f0. Save new-dark.css.
3. Connect to 'Light Table UI'.
4. Open multiple editors, change content in one of them. Don't save!
5. Switch between editors, notice color changes in tab names.
6. Undo/redo the change introduced by this commit. Goto step 5.