### PR TITLE
fix CodeMirror search failing with RegExp syntax

### DIFF
--- a/deploy/core/node_modules/codemirror/search.js
+++ b/deploy/core/node_modules/codemirror/search.js
@@ -45,9 +45,10 @@
   }
   function parseQuery(query) {
     var ignoreCase = query == query.toLowerCase();
+    var isRE = isRegex(query);
     try {
       var rx = new RegExp(isRE[1], isRE[2].indexOf("i") == -1 ? "" : "i");
-      if(isRegex(query) && !"".match(rx)) {
+      if(isRE && !"".match(rx)) {
         return rx;
       } else {
         return query;
@@ -56,7 +57,6 @@
       return query;
     }
   }
-
   function doSearch(cm, query, rev) {
     var state = getSearchState(cm);
     cm.operation(function() {


### PR DESCRIPTION
Commit e6b16d80 broke this by trying to access the undefined isRE
