### PR TITLE
Default hotkey on OSX for searcher is cmd-shift-f

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Add `LightTable/src` to your Light Table workspace and open `src/lt/objs/jump_st
 
 The new Light Table release supports auto-complete (tab), inline docs (ctrl-d) and jump-to-definition (ctrl-. to jump and ctrl-, to jump back) for ClojureScript and Clojure vars, all of which are very useful for exploring the codebase. In ClojureScript these features are only aware of vars that have been eval'd in the current compiler process, so be sure to eval the ns form at the top of the file to get the full effect.
 
-For hunting down behaviors, objects and other things that don't live in vars use the searcher (ctrl-shift-f). If it isn't clear how to use a given function then using the searcher to find examples will also help.
+For hunting down behaviors, objects and other things that don't live in vars use the searcher (ctrl-shift-f or cmd-shift-f on Mac). If it isn't clear how to use a given function then using the searcher to find examples will also help.
 
 Finally, use the documentation searcher (ctrl-shift-d) for full-text search over the names and docstrings of all known vars. Most of Light Table doesn't have docstrings, but this is still useful for library code.
 


### PR DESCRIPTION
Simple update to the documentation in the README, as the existing documentation didn't work as expected on OSX with a non-customized LT setup.
