### PR TITLE
Allow fold-code to fold at location

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -376,8 +376,11 @@
   (object/merge! e {:doc doc})
   (.swapDoc (->cm-ed e) (:doc @doc)))
 
-(defn fold-code [e]
-  (.foldCode (->cm-ed e) (cursor e)))
+(defn fold-code
+  ([e]
+   (fold-code e (->cursor e)))
+  ([e loc]
+   (.foldCode (->cm-ed e) (clj->js loc))))
 
 (defn gutter-widths [e]
   (let [gutter-div (dom/$ :div.CodeMirror-gutters (object/->content e))


### PR DESCRIPTION
Expands `lt.objs.editor/fold-code` to accept two arguments to fold at a line `n` or location `{:line n :ch m}`.

CodeMirror fold options are still not wrapped.
