### PR TITLE
Jump stack fixes

### DIFF
--- a/src/lt/objs/jump_stack.cljs
+++ b/src/lt/objs/jump_stack.cljs
@@ -60,5 +60,4 @@
   :hidden true
   :exec (fn [file pos]
           (when-let [ed (lt.objs.editor.pool/last-active)]
-            (object/raise jump-stack :jump-stack.push! ed file pos))
-          (jump-to file pos))})
+            (object/raise jump-stack :jump-stack.push! ed file pos)))})


### PR DESCRIPTION
Minor fixes that I noticed while using jump-stack in a plugin. The `jump-stack.push` behavior was biting me since I wanted it to use the given editor. The reason it was biting me was because I was [switching the focus to another tab and then calling this behavior](https://github.com/cldwalker/kukui/blob/a4694bfb8efd3febc989d74ff75f1631a56985c3/src/lt/plugins/kukui/query.cljs#L181-L182) so I don't want the last-active editor. The second fix I noticed was just a minor redundancy.
