### PR TITLE
Add duplicate file option to workspace files

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -416,6 +416,7 @@
   :tree-item [:lt.objs.sidebar.workspace/rename-submit
               :lt.objs.sidebar.workspace/rename-focus
               :lt.objs.sidebar.workspace/start-rename
+              :lt.objs.sidebar.workspace/duplicate
               :lt.objs.sidebar.workspace/rename-cancel
               :lt.objs.sidebar.workspace/rename-blur]
   :version [:lt.objs.version/destroy-on-close

--- a/src/lt/objs/sidebar/workspace.cljs
+++ b/src/lt/objs/sidebar/workspace.cljs
@@ -201,11 +201,15 @@
 (behavior ::subfile-menu
           :triggers #{:menu-items}
           :reaction (fn [this items]
-                      (conj items {:label "Rename"
-                                   :order 1
-                                   :click (fn [] (object/raise this :start-rename!))}
-                            {:label "Delete"
+                      (conj items
+                            {:label "Duplicate"
+                             :order 1
+                             :click (fn [] (object/raise this :duplicate!))}
+                            {:label "Rename"
                              :order 2
+                             :click (fn [] (object/raise this :start-rename!))}
+                            {:label "Delete"
+                             :order 3
                              :click (fn [] (object/raise this :delete!))})))
 
 (behavior ::subfolder-menu
@@ -368,6 +372,14 @@
           :reaction (fn [this]
                       (object/merge! this {:renaming? false})
                       ))
+
+(behavior ::duplicate
+          :triggers #{:duplicate!}
+          :reaction (fn [this]
+                      (let [base-name (files/without-ext (files/basename (:path @this)))
+                            new-name (str base-name " copy." (files/ext (:path @this)))
+                            new-path (files/join (files/parent (:path @this)) new-name)]
+                        (files/copy (:path @this) new-path))))
 
 (behavior ::destroy-sub-tree
           :trigger #{:destroy}


### PR DESCRIPTION
Copies the file on disk with the name <original_file_name> copy<ext>

![duplicate](https://cloud.githubusercontent.com/assets/185091/4005099/bd861020-298b-11e4-8360-613aaff81704.gif)
