### PR TITLE
Set width of inputs / files in sidebar

### DIFF
--- a/src/lt/objs/sidebar/workspace.cljs
+++ b/src/lt/objs/sidebar/workspace.cljs
@@ -67,7 +67,11 @@
                       (object/merge! this {:open? true})
                       (when-not (:realized? @this)
                         (object/merge! this {:realized? true})
-                        (object/merge! this (files-and-folders (:path @this))))))
+                        (object/merge! this (files-and-folders (:path @this)))
+                        (let [folder (dom/$ :ul (object/->content this))
+                              width (dom/scroll-width folder)]
+                          (doseq [child (dom/children folder)]
+                            (dom/css child {:width width}))))))
 
 (behavior ::refresh
           :triggers #{:refresh!}

--- a/src/lt/objs/sidebar/workspace.cljs
+++ b/src/lt/objs/sidebar/workspace.cljs
@@ -343,7 +343,9 @@
           :reaction (fn [this]
                       (object/merge! this {:renaming? true})
                       (let [input (dom/$ :input (object/->content this))
-                            len (count (files/without-ext (files/basename (:path @this))))]
+                            len (count (files/without-ext (files/basename (:path @this))))
+                            width (dom/scroll-width (dom/parent input))]
+                        (dom/css input {:width width})
                         (dom/focus input)
                         (dom/selection input 0 len "forward"))))
 

--- a/src/lt/util/dom.cljs
+++ b/src/lt/util/dom.cljs
@@ -149,6 +149,9 @@
 (defn width [elem]
   (.-clientWidth elem))
 
+(defn scroll-width [elem]
+  (.-scrollWidth elem))
+
 (defn offset-top [elem]
   (.-offsetTop elem))
 


### PR DESCRIPTION
In a project with a deeply nested folder structure, renaming the file results in a very small input. This ensures the input is at least as wide as the filename being edited.
There is also a visual change to that maintains the highlight width consistent even when the sidebar needs to scroll.