### PR TITLE
Fixes search cursor reverting position on release of ctrl-s

### DIFF
--- a/src/lt/objs/find.cljs
+++ b/src/lt/objs/find.cljs
@@ -71,12 +71,8 @@
 
 (behavior ::hide!
           :triggers #{:hide!}
-          :reaction (fn [this revert-pos]
+          :reaction (fn [this]
                       (when-let [ed (pool/last-active)]
-                        (when revert-pos
-                          (when-let [pos (:pos @this)]
-                            (editor/move-cursor ed pos)))
-
                             (editor/focus ed))))
 
 (behavior ::next!
@@ -185,8 +181,8 @@
 
 (cmd/command {:command :find.hide
               :desc "Find: Hide the find bar"
-              :exec (fn [revert-pos]
-                      (object/raise bar :hide! revert-pos))})
+              :exec (fn []
+                      (object/raise bar :hide!))})
 
 (cmd/command {:command :find.next
               :desc "Find: Next find result"


### PR DESCRIPTION
## Problem

There's currently a bug in emacs-mode support caused by findbar.  When using `C-s` to iterate through matches, upon releasing the "s" of `C-s`, the cursor reverts to the position of the initial search. This bug does not occur when using enter to trigger the search. Muscle memory of mashing `C-s` always wins out, and since  it doesn't bounce you back until you let go, it can be quite frustrating.
## Cause

The ::search! behavior is triggered on keyup. Releasing "s" of ctrl-s counts as a keyup. For reasons I don't entirely understand, the code to revert the cursors position after an aborted search is part of the ::search! behavior that is always triggered, instead of a parametric part of the ::hide! behavior.

In Emacs, the search cursor is kept if enter is pressed to end the search (or any other key) and returned to the original position if ctrl-g is used.
## Solution

This is the lowest impact solution I could find. Instead of searching on keyup, we search on keydown. This means that releasing `C-s` won't inadvertently activate the final ::search! trigger, which incorrectly reset the position. This does mean that the next time you press C-s, you do get a flash of the original position before resuming the search where you left off, which is visually distracting but harmless.

Many other more invasive solutions exist, and there's probably also an even more elegant non-invasive solution I haven't thought of yet, but this is enough to let me stop tearing my hair out in the meanwhile.
