### PR TITLE
Fix connector failing to connect to LT browser

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -122,6 +122,8 @@
            :lt.objs.clients/try-send]
   :client.local [:lt.objs.clients.local/send!]
   :client.placeholder [:lt.objs.clients/remove-placeholder-on-swapped]
+  :client.selector [:lt.objs.connector/on-close!
+                    :lt.objs.connector/on-selected]
   :clients [:lt.objs.clients/raise-on-object]
   :clients.devtools [:lt.objs.clients.devtools/clear-queue-on-connect
                      :lt.objs.clients.devtools/console-log

--- a/src/lt/objs/connector.cljs
+++ b/src/lt/objs/connector.cljs
@@ -5,34 +5,28 @@
             [lt.objs.eval :as eval])
   (:require-macros [lt.macros :refer [behavior defui]]))
 
-(behavior ::on-selected-cb
-                  :triggers #{:selected}
-                  :reaction (fn [obj client]
-                              (let [cb (@obj :cb)]
-                                (cb client))))
-
-(behavior ::on-selected-destroy
-                  :triggers #{:selected}
-                  :reaction (fn [this client]
-                              (object/raise this :close!)
-                              ))
+(behavior ::on-selected
+          :triggers #{:selected}
+          :reaction (fn [this client]
+                      (when-let [cb (:cb @this)]
+                        (cb client))
+                      (object/raise this :close!)))
 
 (behavior ::on-close!
-                  :triggers #{:close!}
-                  :reaction (fn [this]
-                              (object/raise (:popup @this) :close!)
-                              (object/destroy! this)
-                              ))
+          :triggers #{:close!}
+          :reaction (fn [this]
+                      (object/raise (:popup @this) :close!)
+                      (object/destroy! this)
+                      ))
 
 (defui client-button [obj client]
-       [:li.button (:name @client)]
-       :click (fn []
-                (object/raise obj :selected client)
-                ))
+  [:li.button (:name @client)]
+  :click (fn []
+           (object/raise obj :selected client)
+           ))
 
 (object/object* ::client-selector
-                :triggers []
-                :behaviors [::on-selected-cb ::on-selected-destroy ::on-close!]
+                :tags #{:client.selector}
                 :init (fn [this clients cb]
                         (object/merge! this {:cb cb
                                              :popup
@@ -46,8 +40,8 @@
                         ))
 
 (behavior ::select-client
-                  :triggers #{:select-client}
-                  :reaction (fn [obj potentials cb]
-                              (object/create ::client-selector potentials cb)))
+          :triggers #{:select-client}
+          :reaction (fn [obj potentials cb]
+                      (object/create ::client-selector potentials cb)))
 
 (object/add-behavior! eval/evaler ::select-client)


### PR DESCRIPTION
When attempting to connect to a Light Table browser instance within a
brand new mies (David Nolen's bare bones cljs project template) project,
Light Table fails to connect.

It appears that two behaviors with the same trigger :selected are
executed out of order and the target object is destroyed before the
second behavior has a change to execute. This commit moves the behaviors
into one and formats the code.

**Steps to reproduce**
1. Connect to Light Table as a eval target (needed to generate a choice of eval targets)
2. Create a new mies project and add it to your current workspace.
3. Run `lein cljsbuild once` in the project directory to generate the needed JS files.
4. Eval the index.html file
5. Eval the core.cljs file and choose the browser index.html connection.

This should fail with an error about the `:lt.objs.connector/on-selected-cb` behavior.

**Environment**
- Ubuntu 14.04
- Light Table 0.6.7
