### PR TITLE
Show plugins directory in About tab

### DIFF
--- a/src/lt/objs/version.cljs
+++ b/src/lt/objs/version.cljs
@@ -38,6 +38,7 @@
                             [:dl
                              [:dt "Light Table version"] [:dd (:version deploy/version)]
                              [:dt "Binary version"] [:dd (deploy/binary-version)]
+                             [:dt "Plugins directory" [:dd (files/lt-user-dir "plugins")]]
                              ]
                             (check-button)
                             ]


### PR DESCRIPTION
While walking new users through using LightTable at a Clojure meetup, there was no easy way for users to know where to place their plugins which led to some confusion (for me as well since I didn't know where Window's users place their plugins). I figured displaying this info would make it easier. I can also move this info to the plugins tab if that's more appropriate
