### PR TITLE
Prevent adding same folder and file to workspace #775 #1588 #1217

### DIFF
--- a/src/lt/objs/workspace.cljs
+++ b/src/lt/objs/workspace.cljs
@@ -4,6 +4,7 @@
             [lt.objs.files :as files]
             [lt.objs.command :as cmd]
             [lt.objs.cache :as cache]
+            [lt.objs.notifos :as notifos]
             [cljs.reader :as reader]
             [lt.util.load :as load]
             [lt.util.js :refer [now]]
@@ -207,18 +208,22 @@
 (behavior ::add-file!
                   :triggers #{:add.file!}
                   :reaction (fn [this f]
-                              (when-not (some #{f} (:files (-> @this)))
-                                (add! this :files f)
-                                (object/raise this :add f)
-                                (object/raise this :updated))))
+                              (if-not (some #{f} (:files @this))
+                                (do
+                                  (add! this :files f)
+                                  (object/raise this :add f)
+                                  (object/raise this :updated))
+                                (notifos/set-msg! "This file is already in your workspace." {:class "error"}))))
 
 (behavior ::add-folder!
                   :triggers #{:add.folder!}
                   :reaction (fn [this f]
-                              (when-not (some #{f} (:folders (-> @this)))
-                                (add! this :folders f)
-                                (object/raise this :add f)
-                                (object/raise this :updated))))
+                              (if-not (some #{f} (:folders @this))
+                                (do
+                                  (add! this :folders f)
+                                  (object/raise this :add f)
+                                  (object/raise this :updated))
+                                (notifos/set-msg! "This folder is already in your workspace." {:class "error"}))))
 
 (behavior ::remove-file!
                   :triggers #{:remove.file!}


### PR DESCRIPTION
This is a way to stop appearing bugs with duplicate folders and files in workspace.

I'm not doing anything with existing duplicates in workspace. So user would have to clear workspace and add back all the things.
