### PR TITLE
DRY: comment/uncomment/toggle-comment

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -364,11 +364,12 @@
 (defn line-comment [e from to opts]
   (.lineComment (->cm-ed e) (clj->js from) (clj->js to) (clj->js opts)))
 
-(defn uncomment
-  ([e from to]
-   (uncomment e from to nil))
-  ([e from to opts]
-   (.uncomment (->cm-ed e) (clj->js from) (clj->js to) (clj->js opts))))
+(defn uncomment [e from to opts]
+  (.uncomment (->cm-ed e) (clj->js from) (clj->js to) (clj->js opts)))
+
+(defn toggle-comment [e from to opts]
+  (when-not (uncomment e from to opts)
+    (line-comment e from to opts)))
 
 (defn ->generation [e]
   (.changeGeneration (->cm-ed e)))


### PR DESCRIPTION
BTW in 6cf6d31b37dfaf52c4f0a48f97c32114b60d729a @brabadu modified a bunch of normal functions to arity-overloaded functions in order to get rid of some warnings by passing nil as a default parameter. I think this way we just stash away the warnings without properly resolving them. IMO it would be better to leave the warnings displayed until someone gets irritated enough (as I got) and fixes the warnings properly, just as I did in this patch.