### PR TITLE
Fixed rest of compile-time warnings

### DIFF
--- a/src/lt/objs/clients.cljs
+++ b/src/lt/objs/clients.cljs
@@ -24,6 +24,11 @@
 (defn by-name [n]
   (first (filter #(= n (:name @%)) (vals @cs))))
 
+(defn ->name [client]
+  (if (map? client)
+    (:name client)
+    client))
+
 (defn merge-info [client info]
   (let [{:keys [commands type tags]} info
         info (dissoc info :tags)]

--- a/src/lt/objs/console.cljs
+++ b/src/lt/objs/console.cljs
@@ -142,7 +142,7 @@
                 class))))
 
 (defn clear []
-  (dom/empty! (->ui console)))
+  (dom/empty (->ui console)))
 
 (object/object* ::sidebar.console
                 :tags #{:console}

--- a/src/lt/objs/context.cljs
+++ b/src/lt/objs/context.cljs
@@ -49,6 +49,10 @@
 (defn current []
   @contexts)
 
+(defn group! [ctx group]
+  (swap! ctx->group assoc ctx group)
+  (swap! group->ctx update-in [group] conj ctx))
+
 (defn ->obj [ctx]
   (@ctx->obj ctx))
 

--- a/src/lt/objs/document.cljs
+++ b/src/lt/objs/document.cljs
@@ -128,6 +128,12 @@
 (defn set-val [doc v]
   (.setValue (->cm-doc doc) v))
 
+(defn replace
+  ([d from v]
+   (.replaceRange (->cm-doc d) v (clj->js from)))
+  ([d from to v]
+   (.replaceRange (->cm-doc d) v (clj->js from) (clj->js to))))
+
 
 ;;***************************************************
 ;; Manager

--- a/src/lt/objs/keyboard.cljs
+++ b/src/lt/objs/keyboard.cljs
@@ -124,7 +124,7 @@
 (defn capture-up [key char ev]
   (or (@key-map char) (@key-map (->keystr key ev))))
 
-(def meta-key (if (platform/mac?)
+(def meta (if (platform/mac?)
             "cmd"
             "ctrl"))
 

--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -473,7 +473,7 @@
           :desc "Plugin Manager: render plugin results"
           :reaction (fn [this plugins]
                       (let [ul (dom/$ :.server-plugins (object/->content this))]
-                        (dom/empty! ul)
+                        (dom/empty ul)
                         (->> (remove #(installed? (-> % :info :name)) plugins)
                              (map server-plugin-ui)
                              (dom/fragment)
@@ -519,7 +519,7 @@
           :reaction (fn [this plugins]
                       (object/merge! app/app {::plugins (available-plugins)})
                       (let [ul (dom/$ :.plugins (object/->content this))]
-                        (dom/empty! ul)
+                        (dom/empty ul)
                         (dom/append ul (dom/fragment (map installed-plugin-ui (->> @app/app ::plugins vals (sort-by #(.toUpperCase (:name %))))))))))
 
 (behavior ::on-close

--- a/src/lt/objs/search.cljs
+++ b/src/lt/objs/search.cljs
@@ -114,7 +114,7 @@
           :triggers #{:clear!}
           :reaction (fn [this]
                       (object/merge! this {:timeout nil :results (array) :result-count 0 ::time nil ::filesSearched nil :position [0 -1]})
-                      (dom/empty! (->res this))))
+                      (dom/empty (->res this))))
 
 (behavior ::search!
           :triggers #{:search!}
@@ -149,7 +149,7 @@
                       (if (:replace? info)
                         (do
                           (notifos/done-working (str "Replaced " (:result-count @this) " results in " (/ (:time info) 1000) "s." ))
-                          (dom/empty! (->res this)))
+                          (dom/empty (->res this)))
                         (notifos/done-working (str "Found " (:result-count @this) " results searching " (:total info) " files in " (/ (:time info) 1000) "s." )))))
 
 (behavior ::next!

--- a/src/lt/objs/settings.cljs
+++ b/src/lt/objs/settings.cljs
@@ -130,7 +130,7 @@
 
 
 (defn fix-key [k]
-  (let [k (string/replace k "pmeta" kb/meta-key)
+  (let [k (string/replace k "pmeta" kb/meta)
         keys (string/split k " ")]
     ;;ctrl cmd alt altgr shift
     (reduce #(str % " " %2) (map ->ordered-keystr keys))))

--- a/src/lt/objs/sidebar/navigate.cljs
+++ b/src/lt/objs/sidebar/navigate.cljs
@@ -19,6 +19,11 @@
 (defn file-filters [f]
   (re-seq files/ignore-pattern f))
 
+(defn populate [ws]
+  (let [files (reduce grab-files [] (:folders ws))
+        fs (map #(do {:full % :rel (files/basename %)}) (:files ws))]
+    (vec (filter #(files/file? (:full %)) (remove #(-> % :rel file-filters) (concat files fs))))))
+
 (def populate-bg (background (fn [obj-id {:keys [lim pattern ws]}]
                                (let [fs (js/require "fs")
                                      fpath (js/require "path")

--- a/src/lt/plugins/doc.cljs
+++ b/src/lt/plugins/doc.cljs
@@ -156,7 +156,7 @@
 (behavior ::clear!
           :triggers #{:clear!}
           :reaction (fn [this]
-                      (dom/empty! (dom/$ :.results (object/->content this)))
+                      (dom/empty (dom/$ :.results (object/->content this)))
                       (object/merge! this {:results #{}})))
 
 (behavior ::no-client

--- a/src/lt/util/cljs.cljs
+++ b/src/lt/util/cljs.cljs
@@ -89,6 +89,24 @@
                   :else x))]
         (f x)))))
 
+(defn clj->js
+   "Recursively transforms ClojureScript values to JavaScript.
+sets/vectors/lists become Arrays, Keywords and Symbol become Strings,
+Maps become Objects. Arbitrary keys are encoded to by key->js."
+   [x]
+   (when-not (nil? x)
+     (if (satisfies? IEncodeJS x)
+       (-clj->js x)
+       (cond
+         (keyword? x) (name x)
+         (symbol? x) (str x)
+         (map? x) (let [m (js-obj)]
+                    (doseq [[k v] x]
+                      (aset m (key->js k) (clj->js v)))
+                    m)
+         (coll? x) (apply array (map clj->js x))
+         :else x))))
+
 (defn str-contains? [str x]
   (> (.indexOf str x) -1))
 

--- a/src/lt/util/dom.cljs
+++ b/src/lt/util/dom.cljs
@@ -102,7 +102,7 @@
   (when-let [p (parent elem)]
     (.removeChild p elem)))
 
-(defn empty! [elem]
+(defn empty [elem]
   (set! (.-innerHTML elem) ""))
 
 (defn val [elem & [v]]


### PR DESCRIPTION
Hey,

I fixed rest of the warnings. Now I need a close review, as I might actually broke something with this PR (though I hope I didn't).

There is one more message left, it is about redefinition of `clj->js`, which happens in dependency library fetch.

`WARNING: clj->js already refers to: /clj->js being replaced by: fetch.util/clj->js at line 3 deploy/core/node_modules/lighttable/cljs/fetch/util.cljs`
