### PR TITLE
Move pair keybindings out of default to a behavior

### DIFF
--- a/deploy/settings/default/default.keymap
+++ b/deploy/settings/default/default.keymap
@@ -17,19 +17,19 @@
               "ctrl-," [:editor.unjump]
               "ctrl-d" [:editor.doc.toggle]
               "ctrl-=" [:editor.fold-code]}
-     :editor.keys.normal {"\"" [(:editor.repeat-pair "\"")]
+     :editor.keys.normal {"\"" [:passthrough]
                           "'" [(:editor.repeat-pair "'")]
-                          "(" [(:editor.open-pair "(")]
-                          ")" [(:editor.close-pair ")")]
+                          "(" [:passthrough]
+                          ")" [:passthrough]
                           "pmeta-f" [:find.fill-selection
                                      :find.show]
                           "tab" [:auto-complete]
                           "pmeta-g" [:find.next]
                           "pmeta-shift-g" [:find.prev]
-                          "[" [(:editor.open-pair "[")]
-                          "{" [(:editor.open-pair "{")]
-                          "]" [(:editor.close-pair "]")]
-                          "}" [(:editor.close-pair "}")]
+                          "[" [:passthrough]
+                          "{" [:passthrough]
+                          "]" [:passthrough]
+                          "}" [:passthrough]
                           "backspace" [:editor.backspace-pair
                                        :editor.backspace-indent]}
      :editor.keys.hinting.active {"enter" [:passthrough]}

--- a/src/lt/objs/settings.cljs
+++ b/src/lt/objs/settings.cljs
@@ -325,6 +325,19 @@
                       (concat diffs (keymap-diffs-in (files/lt-user-dir "/settings/")))
                       ))
 
+(def pair-keybindings {:editor.keys.normal {"\"" ['(:editor.repeat-pair "\"")]
+                                            "(" ['(:editor.open-pair "(")]
+                                            ")" ['(:editor.close-pair ")")]
+                                            "[" ['(:editor.open-pair "[")]
+                                            "{" ['(:editor.open-pair "{")]
+                                            "]" ['(:editor.close-pair "]")]
+                                            "}" ['(:editor.close-pair "}")]}})
+
+(behavior ::pair-keymap-diffs
+          :triggers #{:keymap.diffs.user+}
+          :reaction (fn [this diffs]
+                      (concat diffs (list {:+ pair-keybindings}))))
+
 (behavior ::on-behaviors-editor-save
           :triggers #{:saved}
           :reaction (fn [editor]


### PR DESCRIPTION
This addresses pair keys clobbering non-pair keys for 8-12 keyboard layouts as [explained here](https://github.com/LightTable/LightTable/issues/620#issuecomment-59621776). This is a change that will require users who want pair keybindings to bring in the new behavior. I didn't bring in the single quote keybinding since we may revert 82fe8cbfc8001c550182b8ae900c022d003e46c5.
@ibdknox I looked in node-webkit issues and didn't see many keybinding issues so I don't see how this would be fixed there. Since we use mousetrap for keyboard layouts, it's possible this could eventually be fixed by them. I do see open issues for keyboard layouts there e.g. ccampbell/mousetrap#143 and ccampbell/mousetrap#191
