### PR TITLE
Add a travis config to alert when cljsbuild warnings are checked in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: clojure
-
+lein: lein
+script: "! lein cljsbuild once 2>&1 | grep WARNING:"
+jdk:
+- oraclejdk8
 notifications:
-    - email: false
+  irc: "chat.freenode.net#lighttable"
+  email:
+  - gabriel.horner@gmail.com
+  - ibdknox@gmail.com
+  - mike.j.innes@gmail.com
+  - joshuafcole@gmail.com
+  - jamie@scattered-thoughts.net


### PR DESCRIPTION
To start #1647 and to make use of getting our warnings down to zero, this will alert us when a warning is checked in. This currently pings the whole core team. I'll check this in later tomorrow and [enable on travis](https://travis-ci.org/LightTable/LightTable) unless there's a concern
