### PR TITLE
Fixing issue with opening file names containing spaces as command-line parameters

### DIFF
--- a/platform/linux/LightTable
+++ b/platform/linux/LightTable
@@ -35,10 +35,5 @@ ARGS="$@"
 CORRECTED=${ARGS//-/<d>}
 CORRECTED=${CORRECTED// /<s>}
 
-if [ -t 0 ] && [ $# != 0 ]; then
-  #We're in a terminal...
-  LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN "<d><d>dir=`pwd`<s>$CORRECTED" &
-else
-  #We were double clicked
-  LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN &
-fi
+LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN "<d><d>dir=`pwd`<S>$CORRECTED" &
+

--- a/platform/linux64/LightTable
+++ b/platform/linux64/LightTable
@@ -35,10 +35,5 @@ ARGS="$@"
 CORRECTED=${ARGS//-/<d>}
 CORRECTED=${CORRECTED// /<s>}
 
-if [ -t 0 ] && [ $# != 0 ]; then
-  #We're in a terminal...
-  LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN "<d><d>dir=`pwd`<s>$CORRECTED" &
-else
-  #We were double clicked
-  LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN &
-fi
+LD_LIBRARY_PATH="$HERE:$LD_LIBRARY_PATH" $HERE/$BIN "<d><d>dir=`pwd`<S>$CORRECTED" &
+

--- a/platform/mac/light
+++ b/platform/mac/light
@@ -26,10 +26,6 @@ ARGS="$@"
 CORRECTED=${ARGS//-/<d>}
 CORRECTED=${CORRECTED// /<s>}
 
-if [ $# != 0 ]; then
-    LTCLI=true $LTAPPCLI "<d><d>dir=$PWD<s>$CORRECTED" &
-else
-    LTCLI=true $LTAPPCLI &
-fi
+LTCLI=true $LTAPPCLI "<d><d>dir=$PWD<S>$CORRECTED" &
 
 open -a LightTable

--- a/src/lt/objs/cli.cljs
+++ b/src/lt/objs/cli.cljs
@@ -11,11 +11,11 @@
   (:require-macros [lt.macros :refer [behavior]]))
 
 (defn rebuild-argv [argstr]
-  (-> (subs argstr (.indexOf argstr "<d><d>dir"))
-      (string/replace "<d>" "-")
-      (string/replace "<s>" " ")
-      (string/split " ")
-      (to-array)))
+  (to-array
+    (map #(string/replace % "<d>" "-")
+      (map #(string/replace % "<s>" " ")
+        (-> (subs argstr (.indexOf argstr "<d><d>dir"))
+          (string/split #"<S>"))))))
 
 (defn parse-args [argv]
   (-> (.. (node-module "optimist")


### PR DESCRIPTION
Specifically:
- using a different separator <S> to separate arguments than to
  escape spaces <s> in filenames in the deployed Bash script
- doing arguments splitting BEFORE `'s/<S>/ /'` substitution
- getting rid of the 'is invoked in terminal' distinction

Fixes #1762

Tests:
- in a terminal : 

```
$ touch "a b"
$ /opt/LightTable/deploy/LightTable a\ b
```
- same test without a terminal, using the Ubuntu ALT+F2 launcher
- tested the following code in `lein trampoline cljsbuild repl-rhino` :

``` clojure
(ns cljs.user (:require [clojure.string :as string]))

; Old function
(defn rebuild-argv [argstr]
  (-> (subs argstr (.indexOf argstr "<d><d>dir"))
      (string/replace "<d>" "-")
      (string/replace "<s>" " ")
      (string/split #" ")
      (to-array)))
(string/join ";" (rebuild-argv "<d><d>dir=/home/lucas/<s>file<s>name"))
; Return: "--dir=/home/lucas/;file;name"

; New function
(defn rebuild-argv [argstr]
  (map #(string/replace % "<d>" "-")
       (map #(string/replace % "<s>" " ")
            (to-array (string/split (subs argstr (.indexOf argstr "<d><d>dir")) #"<S>")))))
(string/join ";" (rebuild-argv "<d><d>dir=/home/lucas/<S>file<s>name"))
; Return: "--dir=/home/lucas/;file name"
```

For reference, there are the 2 last commits that edited the `rebuild-argv` function :
- [0.5.1 fixes](https://github.com/LightTable/LightTable/commit/c747525758555a45eca1289047e50150bec4748c#diff-d03f7bf743045da7e1e49e701aee9d54L13) on Aug 26, 2013
- [clean import](https://github.com/LightTable/LightTable/commit/296dedb97d3e06a709854284bdf2f59b4b03dac1) on Jul 5, 2013

Side notes:
- the whole space / dash characters escape system looks a bit cumbersome and not documented at all, but I'll keep it that way for now
- I don't get why the `(subs argstr (.indexOf argstr "<d><d>dir")` line is needed, I think it can actually be troublesome if no `<d><d>dir=` option is provided, but I won't touch that in this commit
