### PR TITLE
Updated instructions to run atom-shell Light Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ git clone https://github.com/LightTable/LightTable.git
 cd LightTable
 sh osx_deps.sh
 export LT_HOME=$(pwd)/deploy
-./deploy/light
+cd deploy
+cmod +x ./run.sh
+./run.sh
 ```
 
 On Linux:


### PR DESCRIPTION
Instructions for running Light Table wón atom-shell were out of date. I updated them in Readme file
