### PR TITLE
Filename extensions do not contain directory separators (fix #1755)

### DIFF
--- a/src/lt/objs/files.cljs
+++ b/src/lt/objs/files.cljs
@@ -88,8 +88,8 @@
         (recur (rest parts) (conj acc (string/join "." parts)))))))
 
 (defn ext [path]
-  (let [i (.lastIndexOf path ".")]
-    (when (> i 0)
+  (let [i (.lastIndexOf path ".") j (.lastIndexOf path separator)]
+    (when (and (> i 0) (> i j))
       (subs path (inc i) (count path)))))
 
 (defn without-ext [path]


### PR DESCRIPTION
Very simple attempt to fix #1755 by making the way filename extensions are determined slightly less naïve. I didn't touch without-ext yet (even though it is exactly as buggy) because I didn't know if it was used anywhere that depended on the naïve behavior.
