### PR TITLE
Add behavior to allow users to use CM addons that come with LT

### DIFF
--- a/src/lt/object.cljs
+++ b/src/lt/object.cljs
@@ -122,6 +122,13 @@
   (let [reactions (-> @obj :listeners k)]
     (raise* obj reactions args k)))
 
+(defn call-behavior-reaction
+  "For a given behavior keyword id, call its :reaction fn with given args"
+  [id & args]
+  (let [behavior-fn (:reaction (->behavior id))]
+    (assert behavior-fn)
+    (apply behavior-fn args)))
+
 (defn update-listeners
   ([obj] (update-listeners obj nil))
   ([obj instants]

--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -698,3 +698,20 @@
                                                       "core/node_modules/codemirror/mode")]
                         (load/js path :sync))
                       (aset js/CodeMirror.keyMap.basic "Tab" expand-tab)))
+
+(behavior ::load-addon
+          :triggers #{:object.instant-load}
+          :desc "App: Load CodeMirror addon path(s)"
+          :params [{:label "path(s)"
+                    :example "edit/matchtags.js"}]
+          :type :user
+          :reaction (fn [this path]
+                      (let [paths (map #(files/join (files/lt-home)
+                                                    "core/node_modules/codemirror/addon" %)
+                                       (if (coll? path) path [path]))]
+                        (object/call-behavior-reaction :lt.objs.plugins/load-js
+                                                       this
+                                                       (filter #(= (files/ext %) "js") paths))
+                        (object/call-behavior-reaction :lt.objs.plugins/load-css
+                                                       this
+                                                       (filter #(= (files/ext %) "css") paths)))))

--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -754,8 +754,8 @@
 
 (behavior ::load-js
           :triggers #{:object.instant-load}
-          :desc "App: Load a javascript file"
-          :params [{:label "path"}]
+          :desc "App: Load javascript file(s)"
+          :params [{:label "path(s)"}]
           :type :user
           :reaction (fn [this path]
                       (binding [*plugin-dir* (::dir object/*behavior-meta*)
@@ -779,15 +779,16 @@
 
 (behavior ::load-css
           :triggers #{:object.instant}
-          :desc "App: Load a css file"
-          :params [{:label "path"}]
+          :desc "App: Load css file(s)"
+          :params [{:label "path(s)"}]
           :type :user
           :reaction (fn [this path]
-                      (let [path (adjust-path path)]
-                        (when (or load/*force-reload*
-                                  (not (get (::loaded-files @this) path)))
-                          (object/update! this [::loaded-files] #(conj (or % #{}) path))
-                          (load/css path)))))
+                      (let [paths (map adjust-path (if (coll? path) path [path]))]
+                        (doseq [path paths]
+                          (when (or load/*force-reload*
+                                    (not (get (::loaded-files @this) path)))
+                            (object/update! this [::loaded-files] #(conj (or % #{}) path))
+                            (load/css path))))))
 
 (behavior ::load-keymap
           :triggers #{:object.instant}


### PR DESCRIPTION
This allows users and other plugins to take advantage of [a number of CM addons](https://github.com/LightTable/LightTable/tree/master/deploy/core/node_modules/codemirror/addon) that come with LT after #1772 landed. Some handy ones to try in html are edit/matchtags.js and edit/closetag.js (will be adding these to the HTML plugin on the next LT release). Merging on monday unless there are concerns.
