### PR TITLE
Escape autocomplete hints #1793

### DIFF
--- a/src/lt/plugins/auto_complete.cljs
+++ b/src/lt/plugins/auto_complete.cljs
@@ -9,7 +9,7 @@
             [lt.objs.editor :as editor]
             [lt.objs.context :as ctx]
             [clojure.string :as string]
-            [lt.util.js :refer [wait]]
+            [lt.util.js :refer [wait escape]]
             [lt.util.dom :as dom])
   (:require-macros [lt.macros :refer [behavior defui background]]))
 
@@ -138,12 +138,16 @@
   (str (.-text x) (.-completion x)))
 
 (defn distinct-completions [hints]
-  (let [seen #js {}]
-    (filter (fn [hint]
-              (if (true? (aget seen (.-completion hint)))
-                false
-                (aset seen (.-completion hint) true)))
-            hints)))
+  (let [seen #js {}
+        distinct-hints (filter (fn [hint]
+                          (if (true? (aget seen (.-completion hint)))
+                            false
+                            (aset seen (.-completion hint) true)))
+                        hints)]
+    (map (fn [h] #js {"completion" (.-completion h)
+                      "text" (escape (.-completion h))}) distinct-hints)
+
+    ))
 
 (declare hinter)
 


### PR DESCRIPTION
It took me couple of evenings to dig into this. May need more changes.

Autocomplete plugin relies heavily on `lt.objs.sidebar.command/filter-list` for rendering, sorting etc. So I had to find a proper place to insert escaping. 

This commit escapes autocomplete tokens, so html tags aren't interpreted as tags anymore.  BUT now keys for tokens with escapable symbols can't by used for autocompletion.

Example, in my file I have string "http://fb.me/react-0.12.2.js". Before this change I could type `fb.me/` and still see this token in autocomplete list. With this PR symbol `/` is interpreted as `&#x2F;` so it doesn't match and this line doesn't show up in autocomplete. 

Same for a string that caused a bug in first place. Now I can't autocomplete string `<h1>404</h1>` by typing < ( plugin reads it as `&lt;`). It will find this line if you start with `h1` or `404` though.

Anyway I don't think autocomplete should produce such options like `<h1>404</h1>`. It should give only tag or only text, not whole string.