### PR TITLE
Change osx_deps.sh/windows_deps.sh to curl over https instead of http

### DIFF
--- a/osx_deps.sh
+++ b/osx_deps.sh
@@ -13,7 +13,7 @@ rm -rf deploy/LightTable.app
 rm deploy/light
 
 #get the LightTable.app binary
-curl -O http://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.2/LightTableMac.zip
+curl -O https://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.2/LightTableMac.zip
 unzip LightTableMac.zip
 mv LightTable/* deploy/
 rmdir LightTable/

--- a/windows_deps.sh
+++ b/windows_deps.sh
@@ -8,7 +8,7 @@ fi
 
 ZIPFILE=LightTableWin.zip
 echo "### Fetching binaries ###"
-curl -O http://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.0/$ZIPFILE
+curl -O https://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.0/$ZIPFILE
 unzip $ZIPFILE
 rm $ZIPFILE
 cp -ar deploy/* LightTable


### PR DESCRIPTION
`osx_deps.sh` and `windows_deps.sh` are using insecure http transport to download dependencies. This PR changes the scripts to use https.

Note that `linux_deps.sh` is already using https.