### PR TITLE
Switch off DirectWrite and subpixel font scaling

### DIFF
--- a/deploy/package.json
+++ b/deploy/package.json
@@ -11,7 +11,9 @@
     "web-preferences": {
       "webgl": true,
       "webaudio": true,
-      "plugins": true
+      "plugins": true,
+      "direct-write": false,
+      "subpixel-font-scaling": false
     }
   }
 }


### PR DESCRIPTION
Trying the [atom-shell](https://github.com/LightTable/LightTable/pull/1756) branch I have investigated that it is quite usable except font rendering. I have solved my problem (Linux box, no retina) by switching off subpixel scaling. So I propose to switch to [Atom defaults](https://github.com/atom/atom/blame/master/src/browser/atom-window.coffee#L31-L32) but unsure if it's acceptable for core team MacOS users.

By the way, could we provide a config behavior to tune font rendering? Seems that behavior files are read on early stage of bootstrap process.