### PR TITLE
Add behavior to use CM rulers - close #892

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -715,3 +715,15 @@
                         (object/call-behavior-reaction :lt.objs.plugins/load-css
                                                        this
                                                        (filter #(= (files/ext %) "css") paths)))))
+
+(behavior ::set-rulers
+          :triggers #{:object.instant}
+          :type :user
+          :desc "Editor: Set CodeMirror rulers"
+          :params [{:label "Vector of rulers"
+                    :example "[{:color \"#cfc\" :column 100 :lineStyle \"dashed\"}]"}]
+          :reaction (fn [this rulers]
+                      (when-not (.getOption (->cm-ed this) "rulers")
+                        (load/js "core/node_modules/codemirror/addon/display/rulers.js" :sync))
+                      (let [rulers (or rulers [{:lineStyle "dashed" :color "#aff" :column 80}])]
+                        (set-options this {:rulers (clj->js rulers)}))))


### PR DESCRIPTION
Leverage CM's ruler addon to provide a behavior to add rulers - [screenshot](https://www.dropbox.com/s/ipq7c21w1dkwmg3/Screenshot%202015-01-24%2011.50.25.png?dl=0). Users can use it as follows:

```clojurescript
;; Draw a ruler at 80 chars
[:editor :lt.objs.editor/set-rulers]

;; Or specify multiple rulers
[:editor :lt.objs.editor/set-rulers [{:lineStyle "dashed" :color "#aff" :column 80}
                                                   {:lineStyle "dashed" :color "#aff" :column 120}]]
```
   Will merge this on monday unless there are concerns.