### PR TITLE
Fix css injection-eval filename escaping.

### DIFF
--- a/src/lt/objs/clients/local.cljs
+++ b/src/lt/objs/clients/local.cljs
@@ -42,7 +42,7 @@
           (object/raise clients/clients :message [cb :editor.eval.js.exception {:ex e :meta (:meta data)}])))))
 
 (defmethod on-message :editor.eval.css [_ data cb]
-  (let [name (string/replace (str "local-" (:name data)) #"\." "-")
+  (let [name (str "local-" (string/replace (:name data) #"[^a-zA-Z0-9]+" "-"))
         cur ($ (str "#" name))]
     (when cur
       (remove cur))


### PR DESCRIPTION
Found/fixed during hack night.
CSS files being evaluated are injected as a style tag with an id derived from the file name; the derivation was not properly escaping any characters besides `.`, such as ` `.