### PR TITLE
fix a bug of :editor.force.wrap command

### DIFF
--- a/src/lt/objs/editor/pool.cljs
+++ b/src/lt/objs/editor/pool.cljs
@@ -581,8 +581,14 @@
               :exec (fn []
                       (when-let [ed (last-active)]
                         (if (editor/option ed "lineWrapping")
-                          (object/add-tags ed [:editor.force.unwrap])
-                          (object/add-tags ed [:editor.force.wrap]))))})
+                          (do
+                            (object/remove-tags ed [:editor.force.wrap])
+                            (object/add-tags ed [:editor.force.unwrap])
+                            (notifos/set-msg! "Wrapping off" {:timeout 2000}))
+                          (do
+                            (object/remove-tags ed [:editor.force.unwrap])
+                            (object/add-tags ed [:editor.force.wrap])
+                            (notifos/set-msg! "Wrapping on" {:timeout 2000})))))})
 
 (cmd/command {:command :editor.undo
               :desc "Editor: Undo"


### PR DESCRIPTION
I wrote a comment about this bug(maybe bug...) in the end of this issue(#1810).

I did two things.

- fix a bug.
- add message notifying wrap on and off to indicate which one is done.