### PR TITLE
Update build scripts for atom-shell name change to electron

### DIFF
--- a/script/build-app.sh
+++ b/script/build-app.sh
@@ -14,9 +14,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"; cd ..
 ELECTRON_DIR="shell/electron"
 
 # from: http://stackoverflow.com/a/17072017/142317
-# The download-electron tasks seems to still create an Atom.app executable 
-# so we'll have to reference that until they change it to Electron.app 
-# https://github.com/atom/grunt-download-electron/issues/30
+# Will need to change Atom.app/atom/atom.exe to Electron.app/exe once we move to ^0.24.0 https://github.com/atom/grunt-download-electron/issues/30
 if [ "$(uname)" == "Darwin" ]; then
   OS="mac"
   EXE="Atom.app/Contents/MacOS/Atom"

--- a/script/build-app.sh
+++ b/script/build-app.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 set -e
 
-# Create LightTable release using our local Atom Shell installation
+# Create LightTable release using our local Electron installation
 # (Mac, Linux, or Cygwin)
 
 # Ensure we start in project root
 cd "$(dirname "${BASH_SOURCE[0]}")"; cd ..
 
 #----------------------------------------------------------------------
-# Get OS-specific Atom details
+# Get OS-specific Electron details
 #----------------------------------------------------------------------
 
-ATOM_DIR="shell/atom-shell"
+ELECTRON_DIR="shell/electron"
 
 # from: http://stackoverflow.com/a/17072017/142317
+# The download-electron tasks seems to still create an Atom.app executable 
+# so we'll have to reference that until they change it to Electron.app 
+# https://github.com/atom/grunt-download-electron/issues/30
 if [ "$(uname)" == "Darwin" ]; then
   OS="mac"
   EXE="Atom.app/Contents/MacOS/Atom"
@@ -56,12 +59,12 @@ RELEASE_RSRC="$RELEASE_DIR/$RESOURCES"
 rm -rf $RELEASE_DIR $RELEASE_TARBALL
 
 #----------------------------------------------------------------------
-# Copy Atom installation and app directory into output location
+# Copy Electron installation and app directory into output location
 #----------------------------------------------------------------------
 
 echo "Creating $RELEASE_DIR ..."
 mkdir -p $RELEASE_DIR
-cp -R $ATOM_DIR/* $RELEASE_DIR
+cp -R $ELECTRON_DIR/* $RELEASE_DIR
 rm -f $RELEASE_DIR/version
 cp LICENSE.md $RELEASE_DIR/LICENSE
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -18,7 +18,7 @@ npm --version >/dev/null 2>&1 || { echo >&2 "Please install npm before running t
 # Ensure we start in project root
 cd "$(dirname "${BASH_SOURCE[0]}")"; cd ..
 
-# Ensure we have current version of atom-shell
+# Ensure we have current version of electron 
 pushd shell
   npm install grunt-cli
   npm install

--- a/script/build.sh
+++ b/script/build.sh
@@ -22,7 +22,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"; cd ..
 pushd shell
   npm install grunt-cli
   npm install
-  node_modules/.bin/grunt download-atom-shell
+  node_modules/.bin/grunt download-electron
 popd
 
 # Build the core cljs

--- a/script/light.sh
+++ b/script/light.sh
@@ -9,11 +9,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")"; cd ..
 DIR=$(pwd)
 
 if [ "$(uname)" == "Darwin" ]; then
-  CLI="${DIR}/shell/atom-shell/Atom.app/Contents/MacOS/Atom"
+  CLI="${DIR}/shell/electron/Atom.app/Contents/MacOS/Atom"
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-  CLI="${DIR}/shell/atom-shell/atom"
+  CLI="${DIR}/shell/electron/atom"
 elif [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
-  CLI="${DIR}/shell/atom-shell/atom.exe"
+  CLI="${DIR}/shell/electron/atom.exe"
 else
   echo "Cannot detect a supported OS."
   exit 1

--- a/shell/.gitignore
+++ b/shell/.gitignore
@@ -1,2 +1,2 @@
-atom-shell
+electron
 node_modules

--- a/shell/Gruntfile.js
+++ b/shell/Gruntfile.js
@@ -3,13 +3,13 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
-    "download-atom-shell": {
+    "download-electron": {
       version: "0.22.1",
       outputDir: "./atom-shell",
       rebuild: true
     }
   });
 
-  grunt.loadNpmTasks('grunt-download-atom-shell');
+  grunt.loadNpmTasks('grunt-download-electron');
 
 };

--- a/shell/Gruntfile.js
+++ b/shell/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
     pkg: grunt.file.readJSON('package.json'),
     "download-electron": {
       version: "0.22.1",
-      outputDir: "./atom-shell",
+      outputDir: "./electron",
       rebuild: true
     }
   });

--- a/shell/package.json
+++ b/shell/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "download-atom-shell",
+  "name": "download-electron",
   "version": "0.1.0",
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-download-atom-shell": "^0.10.0"
+    "grunt-download-electron": "^2.0.0"
   }
 }


### PR DESCRIPTION
Github has changed the name of atom-shell to electron as per
https://github.com/atom/electron/pull/1389