### PR TITLE
Switch from atom-shell to electron (new name of a-s)

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -22,7 +22,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"; cd ..
 pushd shell
   npm install grunt-cli
   npm install
-  node_modules/.bin/grunt download-atom-shell
+  node_modules/.bin/grunt download-electron
 popd
 
 # Build the core cljs

--- a/shell/Gruntfile.js
+++ b/shell/Gruntfile.js
@@ -3,13 +3,13 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
-    "download-atom-shell": {
+    "download-electron": {
       version: "0.22.1",
       outputDir: "./atom-shell",
       rebuild: true
     }
   });
 
-  grunt.loadNpmTasks('grunt-download-atom-shell');
+  grunt.loadNpmTasks('grunt-download-electron');
 
 };

--- a/shell/package.json
+++ b/shell/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-download-atom-shell": "^0.10.0"
+    "grunt-download-electron": "^2.1.1"
   }
 }


### PR DESCRIPTION
Name of atom-shell has changed.

Actually, build don't work without this modification (unable to get atom-shell dependencies).