### PR TITLE
Add Git attributes file to disable auto-CRLF conversion for all text files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Disable auto-CRLF for all text files to prevent files being checked-out with CRLF line endings (on Windows)
+* -text


### PR DESCRIPTION
The build fails on Windows if the Git `core.autocrlf` configuration setting is `true` – see issue #1924.

@rundis Thoughts?