### PR TITLE
Better handling of #1789 - Plugin download errors now handled.

### DIFF
--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -320,7 +320,8 @@
   (let [[repo username] (->> (string/split (:source plugin) "/")
                    (reverse)
                    (filter #(not= % ""))
-                   (take 2))]
+                   (take 2))
+        repo (.replace repo #".git" "")]
     (str "https://api.github.com/repos/" username "/" repo "/tarball/" (:version plugin))))
 
 (defn fetch-and-install [url name cb]


### PR DESCRIPTION
Fixed so that downloading of plugins verifies that download succeeds before trying to untar. #1789 indicated that the error was in the gunzip/untar phase, but the problem was really that the download failed and the error response was streamed to file for then to be unzipped etc.. no wonder that failed.

In addition another fix was made. If people add a suffix of .git to the :source attribute in their plugin.edn or plugin.json, the download of plugin tar also fails. Must have worked previously, but apparently not any longer. Anyways any .git to the source path is now stripped off.