### PR TITLE
Optionally zip release files after app build (for Windows).

### DIFF
--- a/script/build-app.sh
+++ b/script/build-app.sh
@@ -52,9 +52,10 @@ BUILDS=builds
 RELEASE="$NAME-$VERSION-$OS"
 RELEASE_DIR="$BUILDS/$RELEASE"
 RELEASE_TARBALL="$BUILDS/${RELEASE}.tar.gz"
+RELEASE_ZIP="${RELEASE}.zip"
 RELEASE_RSRC="$RELEASE_DIR/$RESOURCES"
 
-rm -rf $RELEASE_DIR $RELEASE_TARBALL
+rm -rf $RELEASE_DIR $RELEASE_TARBALL $RELEASE_ZIP
 
 #----------------------------------------------------------------------
 # Copy Electron installation and app directory into output location
@@ -103,11 +104,18 @@ elif [ "$OS" == "windows" ]; then
 fi
 
 #----------------------------------------------------------------------
-# Create tarball
+# Create tarball or zip file
 #----------------------------------------------------------------------
 
 if [ "$1" == "--tarball" ]; then
   tar -zcvf $RELEASE_TARBALL $RELEASE_DIR
+fi
+
+# Create zip file for Cygwin (Windows) using 7-Zip
+if [ "$1" == "--zip" ]; then
+  pushd "$BUILDS"
+  "/cygdrive/c/Program Files/7-Zip/7z.exe" a $RELEASE_ZIP "$RELEASE/*"
+  popd
 fi
 
 echo DONE!


### PR DESCRIPTION
Zip release files after app build for Windows.

@cldwalker @rundis I finally got around to this. The existing archive files referenced by the "download" links on the home page all contain a *LightTable* directory. The zip file produced by these changes will contain a directory named like *lighttable-0.8.0-windows* (which is fine with me).

I'll merge this if no one objects in a day or two.