### PR TITLE
Destroy devtools-client along with parent browser - close #1975

### DIFF
--- a/src/lt/objs/browser.cljs
+++ b/src/lt/objs/browser.cljs
@@ -139,6 +139,7 @@
                   :triggers #{:close}
                   :reaction (fn [this]
                               (object/raise this :inactive)
+                              (object/destroy! (:devtools-client @this))
                               (object/destroy! this)))
 
 (behavior ::rem-client


### PR DESCRIPTION
@rundis I was able to replicate the issue by opening and closing a browser tab or with your instructions. Since the clear-console command looks for [all devtools-client objects](https://github.com/LightTable/LightTable/blob/1d9dd0cc3154048834aedd554a056acb0a2df127/src/lt/objs/console.cljs#L255) and tries to communicate with them, it makes sense to destroy the browser's devtools object when the browser object was destroyed.