### PR TITLE
Bump default plugin versions

### DIFF
--- a/deploy/core/package.json
+++ b/deploy/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "LightTable",
   "description": "LightTable Electron App",
-  "version": "0.8.0",
+  "version": "0.8.0-alpha",
   "main": "main.js",
   "browserWindowOptions": {
     "icon": "img/lticon.png",

--- a/deploy/core/version.json
+++ b/deploy/core/version.json
@@ -1,1 +1,1 @@
-{"version":"0.7.2","electron":"0.31.1"}
+{"version":"0.8.0-alpha","electron":"0.31.1"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lighttable "0.8.0"
+(defproject lighttable "0.8.0-alpha"
   :description "Light Table is a new interactive IDE that lets you modify running programs and embed anything from websites to games. It provides the real time feedback we need to not only answer questions about our code, but to understand how our programs really work."
   :url "http://www.lighttable.com/"
   :dependencies [[org.clojure/clojure "1.5.1"]

--- a/script/build.sh
+++ b/script/build.sh
@@ -33,7 +33,7 @@ fi
 lein cljsbuild clean && lein cljsbuild once
 
 # Fetch plugins
-PLUGINS=("Clojure,0.1.3" "CSS,0.0.6" "HTML,0.0.2" "Javascript,0.1.3"
+PLUGINS=("Clojure,0.2.0" "CSS,0.0.6" "HTML,0.0.2" "Javascript,0.1.3"
          "Paredit,0.0.4" "Python,0.0.7" "Rainbow,0.0.8")
 
 # Plugins cache

--- a/script/build.sh
+++ b/script/build.sh
@@ -33,7 +33,7 @@ fi
 lein cljsbuild clean && lein cljsbuild once
 
 # Fetch plugins
-PLUGINS=("Clojure,0.1.0" "CSS,0.0.6" "HTML,0.0.2" "Javascript,0.1.2"
+PLUGINS=("Clojure,0.1.0" "CSS,0.0.6" "HTML,0.0.2" "Javascript,0.1.3"
          "Paredit,0.0.4" "Python,0.0.5" "Rainbow,0.0.8")
 
 # Plugins cache

--- a/script/build.sh
+++ b/script/build.sh
@@ -33,8 +33,8 @@ fi
 lein cljsbuild clean && lein cljsbuild once
 
 # Fetch plugins
-PLUGINS=("Clojure,0.1.0" "CSS,0.0.6" "HTML,0.0.2" "Javascript,0.1.3"
-         "Paredit,0.0.4" "Python,0.0.5" "Rainbow,0.0.8")
+PLUGINS=("Clojure,0.1.3" "CSS,0.0.6" "HTML,0.0.2" "Javascript,0.1.3"
+         "Paredit,0.0.4" "Python,0.0.7" "Rainbow,0.0.8")
 
 # Plugins cache
 mkdir -p deploy/plugins


### PR DESCRIPTION
@cldwalker @rundis FYI

Plugins with changes not included in the latest version:

 - [Paredit](https://github.com/LightTable/Paredit/commits/master)
 - [CSS](https://github.com/LightTable/CSS/commits/master)
 - [HTML](https://github.com/LightTable/HTML/commits/master)