### PR TITLE
Fix installing a plugin doesn't load new behavior- close #1970

### DIFF
--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -492,8 +492,8 @@
            (dom/prevent e)
            (dom/stop-propagation e)
            (discover-deps plugin (fn []
-                                   (cmd/exec! :behaviors.reload)
-                                   (object/raise manager :refresh!)))))
+                                   (object/raise manager :refresh!)
+                                   (cmd/exec! :behaviors.reload)))))
 
 (defui install-button [plugin]
   [:span.install]
@@ -501,8 +501,8 @@
            (this-as me
                     (discover-deps plugin (fn []
                                             (dom/remove (dom/parent me))
-                                            (cmd/exec! :behaviors.reload)
-                                            (object/raise manager :refresh!))))
+                                            (object/raise manager :refresh!)
+                                            (cmd/exec! :behaviors.reload))))
            (dom/prevent e)
            (dom/stop-propagation e)))
 


### PR DESCRIPTION
@kenny-evitt @rundis This fixes the long-standing bug with an installed plugin not showing new behaviors, commands and keymap :) @kenny-evitt You should be able to install Vim as you did on the issue you filed and just have it work. Fix explained in commit
