### PR TITLE
Fix uninstall message

### DIFF
--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -121,7 +121,6 @@
     (-> (reduce (fn [final [name version]]
                   (let [name (cljs.core/name name)]
                     (if-let [cur (or (get all name) (get final name))]
-                      ;;check if it's newer
                       (if (deploy/is-newer? (:version cur) version)
                         (assoc! final name {:name name
                                             :version version})


### PR DESCRIPTION
@kenny-evitt @rundis This fixes #1944 which I had thought was fixed back in 7b3ebf1a768d835b195c59b620d0cbd512de8349. I also cleaned up `available-plugins` as having the options dynamic in one place and hardcoded in another was making this confusing to read. By breaking them into more smaller usable chunks less option passing is needed. When QAing, I tried edge cases like deleting a plugin directory and then seeing if the manager would prompt me to install it