### PR TITLE
Implement a hint length limit for auto-complete #1635

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -399,6 +399,7 @@
  [:hinter :lt.plugins.auto-complete/escape!]
  [:hinter :lt.plugins.auto-complete/select-unknown]
  [:hinter :lt.plugins.auto-complete/line-change]
+ [:hinter :lt.plugins.auto-complete/set-hint-limit 1000]
 
  [:inline.doc :lt.plugins.doc/clear]
 


### PR DESCRIPTION
Hi guys!

I decided to address a beginner-level bug. Not sure about `remove-long-completitions` function name and everything else to be honest.

Best,
Dmitriy
