### PR TITLE
Fix version sorting for building plugin cache data. Fixes #2043

### DIFF
--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -197,8 +197,8 @@
 (defn version-sort [a b]
   (cond
    (= a b) 0
-   (deploy/is-newer? a b) 1
-   :else -1))
+   (deploy/is-newer? a b) -1
+   :else 1))
 
 (defn build-cache [sha]
   (let [items (filter files/dir? (files/full-path-ls metadata-dir))
@@ -207,7 +207,7 @@
                           :let [versions (->> (files/full-path-ls plugin)
                                               (filter files/dir?)
                                               (map plugin-info)
-                                              (sort-by #(version-sort % %2))
+                                              (sort-by :version version-sort)
                                               (vec))
                                 latest (last versions)]]
                       [(:name latest) {:versions (into {} (map (juxt :version identity) versions))


### PR DESCRIPTION
Previously `build-cache` was attempting to sort plugin versions but [`sort-by`](https://clojuredocs.org/clojure.core/sort-by) was being called with the version comparator being passed as the sort key function. The version comparator was also inverting the standard return values for a comparator – see [`compare`](https://clojuredocs.org/clojure.core/compare) for an example.