### PR TITLE
Improve new user experience

### DIFF
--- a/deploy/core/User/user.behaviors
+++ b/deploy/core/User/user.behaviors
@@ -16,7 +16,7 @@
 ;; * Optional arguments are arguments to pass to a behavior. If a behavior has arguments they should
 ;;   pop up in an info box after the behavior has been autocompleted.
 ;;
-;; * For more on configuring behaviors, [see this doc](doc/behavior-and-keymap-configuration.md).
+;; * For more on configuring behaviors see https://github.com/LightTable/LightTable/blob/master/doc/behavior-and-keymap-configuration.md.
 
 [
  ;; The app tag is kind of like global scope. You assign behaviors that affect

--- a/deploy/core/User/user.behaviors
+++ b/deploy/core/User/user.behaviors
@@ -1,13 +1,22 @@
 ;; User behaviors
 ;; -----------------------------
-;; Behaviors are stored as a set of diffs that are merged together
-;; to create the final set of functionality that makes up Light Table. You can
-;; modify these diffs to either add or subtract functionality.
+;; Modify this file to add and subtract behaviors. Behaviors allow customization of
+;; almost any aspect of LightTable e.g. show line numbers or current theme.
+;; A behavior has the following format:
 ;;
-;; Behaviors are added to tags, objects with those tags then automatically gain
-;; whatever logic the behavior imparts. To see a list of user-level behaviors,
-;; start typing a word related to the functionality you want in between the square
-;; brackets (e.g. "theme").
+;;   [:TAG :BEHAVIOR OPTIONAL_ARGUMENTS]
+;;
+;; * A tag indicates in what context the behavior applies. Common tags are :app and :editor which respectively
+;;   indicate the behavior can be used anywhere and the behavior only applies to editors.
+;;
+;; * Behavior is the specific LightTable behavior to configure. To search available behaviors,
+;;   start typing a search term after :TAG. Once you've found the desired behavior, press TAB to have autocomplete
+;;   fill in the behavior name.
+;;
+;; * Optional arguments are arguments to pass to a behavior. If a behavior has arguments they should
+;;   pop up in an info box after the behavior has been autocompleted.
+;;
+;; * For more on configuring behaviors, [see this doc](doc/behavior-and-keymap-configuration.md).
 
 [
  ;; The app tag is kind of like global scope. You assign behaviors that affect
@@ -27,5 +36,17 @@
 
  ;; To subtract a behavior, prefix the name with '-' e.g.
  ;;  [:app :-lt.objs.intro/show-intro]
+
+
+ ;; Common behaviors to consider
+ ;; ============================
+ ;; Show line numbers
+ ;; [:editor :lt.objs.editor/line-numbers]
+ ;; Customize font
+ ;; [:app :lt.objs.style/font-settings "Courier New" "11"]
+ ;; Auto-close characters '{[("'. Currently only works in English keyboards
+ ;; [:app :lt.objs.settings/pair-keymap-diffs]
+ ;; Tab settings: Use real tabs, tab size in spaces, spaces per indent
+;; [:editor :lt.objs.editor/tab-settings false 2 2]
 ]
 

--- a/deploy/core/User/user.keymap
+++ b/deploy/core/User/user.keymap
@@ -1,19 +1,25 @@
 ;; User keymap
 ;; -----------------------------
-;; Keymaps are stored as a set of diffs that are merged together to create
-;; the final set of keys. You can modify these diffs to either add or
-;; subtract bindings.
+;; Modify this file to add and subtract keybindings (keyboard shortcuts).
+;; Keybindings allow custom keys to invoke any desired LightTable functionality that is behind a command.
+;; A keybinding has the following format:
 ;;
-;; Like behaviors, keys are bound by tag. When objects with those tags are active
-;; the key bindings are live. Keys can be bound to any number of Light Table commands,
-;; allowing you the flexibility to execute multiple operations together. To see a list
-;; of all the commands you can execute, start typing a word related to the thing you
-;; want to do in between the square brackets (e.g. type "editor").
-
+;;   [:TAG "KEYS" :COMMAND]
+;;
+;; * A tag indicates in what context the keybinding applies. Common tags are :app and :editor which respectively
+;;   indicate the keybinding can be used anywhere and the keybinding can only be used when editing text.
+;;
+;; * Keys are the actual keys you type for the keybinding. Most keybindings start with modifier(s) e.g. alt or control.
+;;   Keybindings with modifiers have the format "modifier(s)-key". For example "alt-shift-x" means press alt, shift and x
+;;   at once. See [this doc](doc/behavior-and-keymap-configuration.md#keys) for more on configuring keys.
+;;
+;; * Command is the specific LightTable command(s) to invoke. To search available commands,
+;;   start typing a search term after "KEYS". Once you've found the desired command, press TAB to have autocomplete
+;;   fill in the command name. See [this doc](doc/behavior-and-keymap-configuration.md#commands-in-keybindings) for more on configuring commands.
 [
  [:editor "alt-w" :editor.watch.watch-selection]
  [:editor "alt-shift-w" :editor.watch.unwatch]
 
- ;; To subtract a binding, prefix the key with '-'  e.g.
+ ;; To subtract a keybinding, prefix the key with '-'  e.g.
  ;;  [:app "-ctrl-shift-d" :docs.search.show]
 ]

--- a/deploy/core/User/user.keymap
+++ b/deploy/core/User/user.keymap
@@ -11,11 +11,11 @@
 ;;
 ;; * Keys are the actual keys you type for the keybinding. Most keybindings start with modifier(s) e.g. alt or control.
 ;;   Keybindings with modifiers have the format "modifier(s)-key". For example "alt-shift-x" means press alt, shift and x
-;;   at once. See [this doc](doc/behavior-and-keymap-configuration.md#keys) for more on configuring keys.
+;;   at once. For more on configuring keys see https://github.com/LightTable/LightTable/blob/master/doc/behavior-and-keymap-configuration.md#keys.
 ;;
 ;; * Command is the specific LightTable command(s) to invoke. To search available commands,
 ;;   start typing a search term after "KEYS". Once you've found the desired command, press TAB to have autocomplete
-;;   fill in the command name. See [this doc](doc/behavior-and-keymap-configuration.md#commands-in-keybindings) for more on configuring commands.
+;;   fill in the command name. For more on configuring commands see https://github.com/LightTable/LightTable/blob/master/doc/behavior-and-keymap-configuration.md#commands-in-keybindings.
 [
  [:editor "alt-w" :editor.watch.watch-selection]
  [:editor "alt-shift-w" :editor.watch.unwatch]

--- a/doc/behavior-and-keymap-configuration.md
+++ b/doc/behavior-and-keymap-configuration.md
@@ -31,7 +31,7 @@ a browser. Here are some common ones:
 
 For more tags see the ones used by default in
 [default.keymap](../deploy/settings/default/default.keymap) and
-[default.beahviors](../deploy/settings/default/default.behaviors) and search
+[default.behaviors](../deploy/settings/default/default.behaviors) and search
 LightTable for when a context tag is added with
 [ctx/in!](https://github.com/LightTable/LightTable/search?utf8=%E2%9C%93&q=%22ctx%2Fin%21%22&type=Code).
 

--- a/doc/behavior-and-keymap-configuration.md
+++ b/doc/behavior-and-keymap-configuration.md
@@ -1,0 +1,57 @@
+This document assumes [the user.keymap
+introduction](../deploy/core/User/user.keymap) and [the user.behaviors
+introduction](../deploy/core/User/user.behaviors) have been read.
+
+## Introduction
+
+Keymap and behaviors files are ClojureScript data that when merged together
+create LightTable's final keys and functionality. A user can add or remove any
+keybinding/behavior. This is powerful as any default keybinding/behavior,
+whether from LightTable or a plugin, can be removed or overridden by a user.
+Next this document will cover configuring behaviors and keybindings through
+tags, keys and commands.
+
+## Tags
+
+Tags allow keybindings/behaviors to apply in different contexts i.e. `enter`
+means something different in a url bar vs a popup. Under the hood, objects have
+tags added and removed which makes a keybinding/behavior apply or not apply to
+them respectively. Tags can have optional extensions that make them apply in
+different contexts. For example to have the `:editor` tag only apply to a file
+for a given filetype use the format `:editor.FILETYPE` e.g.
+`:editor.javascript`. Note that for the same keybinding/behavior a tag with
+an extension takes precedence over one without.
+
+There are a number of tags that only apply in a unique UI context or widget e.g.
+a browser. Here are some common ones:
+
+* :browser - Applies when inside a browser tab
+* :editor.keys.hinting.active - Applies when hinting/autocomplete is active
+* :filter-list.input - Applies when in a filter-list e.g. Commands pane or Navigator
+
+For more tags see the ones used by default in
+[default.keymap](../deploy/settings/default/default.keymap) and
+[default.beahviors](../deploy/settings/default/default.behaviors) and search
+LightTable for when a context tag is added with
+[ctx/in!](https://github.com/LightTable/LightTable/search?utf8=%E2%9C%93&q=%22ctx%2Fin%21%22&type=Code).
+
+## Keys
+
+LightTable uses [mousetrap](https://github.com/ccampbell/mousetrap) for keyboard
+handling. Mousetrap recognizes the following modifier keys: `shift, ctrl,
+alt/option and command/cmd`. LightTable also recognizes pmeta which is
+command/cmd in OSX and ctrl anywhere else. To specify other special keys like
+'enter' see [this Mousetrap documentation](https://craig.is/killing/mice#keys).
+LightTable also supports key combinations/sequences when keys are separated by a
+space. This allows plugins like Emacs to support key chords like 'ctrl-x u'.
+
+## Commands In Keybindings
+
+Keybindings can run multiple commands by appending them to the end e.g. `[:TAG
+"KEYS" :COMMAND1 :COMMAND2]`. While commands are started serially, there isn't a
+guarantee that one command is fully finished before the next proceeds. Any
+commands that have asynchronous functionality e.g. interaction with a network or
+filesystem cannot guarantee when their functionality is complete. Commands can
+have arguments passed to them by wrapping them in parenthesis e.g. `(:COMMAND
+ARG1 ARG2)`. For example `[:tabs "pmeta-1" (:tabs.goto 0)]` is a default
+keybinding that passes `0` as an argument to the `:tabs.goto` command.

--- a/src/lt/objs/menu.cljs
+++ b/src/lt/objs/menu.cljs
@@ -126,6 +126,9 @@
                                          (cmd-item "Open recent workspace" :workspace.show-recents {})
                                          (cmd-item "Save file" :save)
                                          (cmd-item "Save file as.." :save-as)
+                                         {:label "Settings" :submenu [(cmd-item "User keymap" :keymap.modify-user)
+                                                                      (cmd-item "User behaviors" :behaviors.modify-user)
+                                                                      (cmd-item "User script" :user.modify-user)]}
                                          {:type "separator"}
                                          (cmd-item "New window" :window.new)
                                          (cmd-item "Close window" :window.close)
@@ -154,6 +157,7 @@
                                          (cmd-item "Connections" :show-connect)
                                          (cmd-item "Navigator" :navigate-workspace-transient)
                                          (cmd-item "Commands" :show-commandbar-transient)
+                                         (cmd-item "Plugin Manager" :plugin-manager.show)
                                          {:type "separator"}
                                          (cmd-item "Language docs" :docs.search.show)
                                          {:type "separator"}


### PR DESCRIPTION
Over the past couple weeks, I've had some designers (non backend people) at my coworking space trying out LightTable. The feedback was pretty consistent in that user.keymap and user.behaviors explanations were confusing (they don't know what diffs and objects are). To address this I revamped the user.keymap and user.behaviors explanations to be more practical and created a separate document for describing configuration in detail. I also added menu items for functionality users were looking for but not finding since they weren't familiar with the command pane. Even when they found the command pane, these new users preferred to access them through the menu. Given configuration/settings and the plugin manager are integral parts of using LightTable, I think adding them to the menu will help new users.