### PR TITLE
Upgrade to Electron 0.34.5

### DIFF
--- a/deploy/core/version.json
+++ b/deploy/core/version.json
@@ -1,1 +1,1 @@
-{"version":"0.8.0-alpha","electron":"0.31.1"}
+{"version":"0.8.0-alpha","electron":"0.34.5"}

--- a/deploy/electron/Gruntfile.js
+++ b/deploy/electron/Gruntfile.js
@@ -4,7 +4,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     "download-electron": {
-      version: "0.31.1",
+      version: "0.34.5",
       outputDir: "./electron",
       rebuild: true
     }

--- a/doc/developer-install.md
+++ b/doc/developer-install.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - [Leiningen 2.x](http://leiningen.org/)
-- [io.js and npm](https://iojs.org/). To avoid clobbering an existing node install, [use nvm](https://github.com/creationix/nvm).
+- [node.js and npm](https://nodejs.org/)
 
 ## OS Specific Prerequisites
 

--- a/doc/for-committers.md
+++ b/doc/for-committers.md
@@ -13,7 +13,7 @@ Current ClojureScript version and libraries we use are in [project.clj](https://
 
 ### Node packages
 
-Node package installs last done with io.js v2.5.0 and npm v2.13.2.
+Node package installs last done with node.js v2.5.0 and npm v2.13.2.
 
 Node dependencies are at deploy/core/node\_modules/. This directory is currently a mix of vendored
 dependencies, forked dependencies and Light Table specific libraries:


### PR DESCRIPTION
Doing the upgrade because our auto-updating notification doesn't work from 0.x.x-alpha to 0.x.x. Also we're doing a full QA for 0.8.0, so we may as well pull in upstream bug fixes with an upgrade.
Held off on upgrading to 0.35.0 since there are ipc changes to handle. Also worth noting that https://github.com/atom/electron/releases/tag/v0.33.4 moved devtools-* events. Our code still works fine for now but something we'll eventually want to change

I ran through about 1/2 the QA checklist on OSX and found no new issues. @rundis @kenny-evitt Could one of you try some of the QA on linux or windows? We can always revert this if it fails our full QA