### PR TITLE
Fix opening file from osx file manager - close #2053

### DIFF
--- a/src/lt/objs/cli.cljs
+++ b/src/lt/objs/cli.cljs
@@ -43,8 +43,11 @@
   on first window since subsequent windows don't open path arguments."
   []
   (and (app/first-window?)
-       (or (seq (if js/process.env.LT_DEV_CLI (subvec argv 2) (rest argv)))
-           (seq open-files))))
+       ;; OSX adds an extra apple event argument to argv when opening a file from a
+       ;; file manager e.g. ["/path/to/electron" "-psn_0_12381134"]. Rather than add
+       ;; a brittle check to remove that argument, check open-files first
+       (or (seq open-files)
+           (seq (if js/process.env.LT_DEV_CLI (subvec argv 2) (rest argv))))))
 
 ;;*********************************************************
 ;; Behaviors


### PR DESCRIPTION
This fixes #2053 in a clean way. I originally tried 6cbc2d6c813ca36013f819e2383fa98f0faeb8ba but I think checking for a stringified Apple event is brittle and error-prone. I [verified upstream with Electron](https://github.com/atom/electron/issues/3657) that this an expected behavior when opening a file from a file manager in osx. I verified that changing ordering of arguments doesn't effect opening files from the commandline in osx and linux
@rundis @kenny-evitt I'll leave this open till Friday and then merge unless there are any concerns