### PR TITLE
[PR] Cleanup duplicated error handling #1966

### DIFF
--- a/src/lt/object.cljs
+++ b/src/lt/object.cljs
@@ -132,14 +132,9 @@
          (apply func obj args))
        (when-not (= trigger :object.behavior.time)
          (raise obj :object.behavior.time r time trigger)))
-       (catch js/Error e
+       (catch :default e
          (safe-report-error (str "Invalid behavior: " (-> (->behavior r) :name)))
-         (safe-report-error e)
-         )
-       (catch js/global.Error e
-         (safe-report-error (str "Invalid behavior: " (-> (->behavior r) :name)))
-         (safe-report-error e)
-         )))))
+         (safe-report-error e))))))
 
 (defn raise
   "Invoke object's behavior fns for given trigger. Args are passed to behavior fns"

--- a/src/lt/objs/clients/tcp.cljs
+++ b/src/lt/objs/clients/tcp.cljs
@@ -71,8 +71,9 @@
       (.listen s 0)
       (.on s "listening" #(set! port (.-port (.address s))))
       s)
-    ;;TODO: warn the user that they're not connected to anything
-    (catch :default e)))
+    (catch :default e
+      ;; TODO: warn the user that they're not connected to anything
+      e)))
 
 (behavior ::send!
                   :triggers #{:send!}
@@ -85,5 +86,6 @@
                   :reaction (fn [app]
                               (try
                                 (.close server)
-                                (catch :default e))))
+                                (catch :default e
+                                  e))))
 

--- a/src/lt/objs/clients/tcp.cljs
+++ b/src/lt/objs/clients/tcp.cljs
@@ -46,9 +46,7 @@
             next (subs buf (inc loc))
             data (try
                    (js->clj (.parse js/JSON cur) :keywordize-keys true)
-                   (catch js/Error e
-                     (console/error e))
-                   (catch js/global.Error e
+                   (catch :default e
                      (console/error e)))]
         (cb data)
         (recur (.indexOf next "\n") next))
@@ -74,10 +72,7 @@
       (.on s "listening" #(set! port (.-port (.address s))))
       s)
     ;;TODO: warn the user that they're not connected to anything
-    (catch js/Error e
-      )
-    (catch js/global.Error e
-      )))
+    (catch :default e)))
 
 (behavior ::send!
                   :triggers #{:send!}
@@ -90,6 +85,5 @@
                   :reaction (fn [app]
                               (try
                                 (.close server)
-                                (catch js/Error e)
-                                (catch js/global.Error e))))
+                                (catch :default e))))
 

--- a/src/lt/objs/clients/ws.cljs
+++ b/src/lt/objs/clients/ws.cljs
@@ -76,5 +76,4 @@
                   :reaction (fn [app]
                               (try
                                 (.close server)
-                                (catch js/Error e)
-                                (catch js/global.Error e))))
+                                (catch :default e))))

--- a/src/lt/objs/clients/ws.cljs
+++ b/src/lt/objs/clients/ws.cljs
@@ -76,4 +76,5 @@
                   :reaction (fn [app]
                               (try
                                 (.close server)
-                                (catch :default e))))
+                                (catch :default e
+                                  e))))

--- a/src/lt/objs/console.cljs
+++ b/src/lt/objs/console.cljs
@@ -23,9 +23,7 @@
                     (files/mkdir (files/lt-user-dir)))
                   (files/mkdir logs-dir))
                 (.. (js/require "fs") (createWriteStream (files/join logs-dir (str "window" (app/window-number) ".log"))))
-                (catch js/global.Error e
-                  (.error js/console (str "Failed to initialize the log writer: " e)))
-                (catch js/Error e
+                (catch :default e
                   (.error js/console (str "Failed to initialize the log writer: " e)))))
 
 (defn ->ui [c]

--- a/src/lt/objs/eval.cljs
+++ b/src/lt/objs/eval.cljs
@@ -113,7 +113,7 @@
   (try
     (reader/read-string r)
     (catch :default e
-      r)))
+      e)))
 
 (defn find-client [{:keys [origin command info key create] :as opts}]
   (let [[result client] (clients/discover command info)

--- a/src/lt/objs/files.cljs
+++ b/src/lt/objs/files.cljs
@@ -304,7 +304,7 @@
        (:dirs opts) (filter #(dir? (join path %)) fs)
        :else fs))
     (catch :default e
-      nil)))
+      e)))
 
 (defn full-path-ls
   "Return directory's files as full paths"
@@ -319,7 +319,8 @@
   [path]
   (try
     (filter dir? (map (partial join path) (.readdirSync fs path)))
-    (catch :default e)))
+    (catch :default e
+      e)))
 
 (defn home
   "Return users' home directory (e.g. ~/) or path under it"

--- a/src/lt/objs/files.cljs
+++ b/src/lt/objs/files.cljs
@@ -184,13 +184,9 @@
                :type (or (path->mode path) e)})
           (object/raise files-obj :files.open content))
         ))
-    (catch js/Error e
+    (catch :default e
       (object/raise files-obj :files.open.error path e)
-      (when cb (cb nil e)))
-    (catch js/global.Error e
-      (object/raise files-obj :files.open.error path e)
-      (when cb (cb nil e)))
-    ))
+      (when cb (cb nil e)))))
 
 (defn open-sync
   "Open file and return map with file's content in :content"
@@ -205,13 +201,9 @@
            :line-ending (determine-line-ending content)
            :type (or (ext->mode (keyword e)) e)}))
         )
-    (catch js/Error e
+    (catch :default e
       (object/raise files-obj :files.open.error path)
-      nil)
-    (catch js/global.Error e
-      (object/raise files-obj :files.open.error path)
-      nil)
-    ))
+      nil)))
 
 (defn save
   "Save path with given content. Optional callback called after save"
@@ -220,14 +212,9 @@
     (.writeFileSync fs path content)
     (object/raise files-obj :files.save path)
     (when cb (cb))
-    (catch js/global.Error e
+    (catch :default e
       (object/raise files-obj :files.save.error path e)
-      (when cb (cb e))
-      )
-    (catch js/Error e
-      (object/raise files-obj :files.save.error path e)
-      (when cb (cb e))
-      )))
+      (when cb (cb e)))))
 
 (defn append
   "Append content to path. Optional callback called after append"
@@ -236,14 +223,9 @@
     (.appendFileSync fs path content)
     (object/raise files-obj :files.save path)
     (when cb (cb))
-    (catch js/global.Error e
+    (catch :default  e
       (object/raise files-obj :files.save.error path e)
-      (when cb (cb e))
-      )
-    (catch js/Error e
-      (object/raise files-obj :files.save.error path e)
-      (when cb (cb e))
-      )))
+      (when cb (cb e)))))
 
 (defn trash! [path]
   (.moveItemTotrash shell path))
@@ -329,9 +311,7 @@
   [path]
   (try
     (doall (map (partial join path) (.readdirSync fs path)))
-    (catch js/Error e
-      (js/lt.objs.console.error e))
-    (catch js/global.Error e
+    (catch :default e
       (js/lt.objs.console.error e))))
 
 (defn dirs
@@ -339,8 +319,7 @@
   [path]
   (try
     (filter dir? (map (partial join path) (.readdirSync fs path)))
-    (catch js/Error e)
-    (catch js/global.Error e)))
+    (catch :default e)))
 
 (defn home
   "Return users' home directory (e.g. ~/) or path under it"

--- a/src/lt/objs/files.cljs
+++ b/src/lt/objs/files.cljs
@@ -286,7 +286,7 @@
        (if cb
          (cb fs)
          fs))
-     (catch js/global.Error e
+     (catch :default e
        (when cb
          (cb nil))
        nil))))
@@ -303,7 +303,7 @@
        (:files opts) (filter #(file? (join path %)) fs)
        (:dirs opts) (filter #(dir? (join path %)) fs)
        :else fs))
-    (catch js/global.Error e
+    (catch :default e
       nil)))
 
 (defn full-path-ls

--- a/src/lt/objs/menu.cljs
+++ b/src/lt/objs/menu.cljs
@@ -24,9 +24,7 @@
                                     (try
                                       (when-let [func (:click opts)]
                                         (func))
-                                      (catch js/Error e
-                                        (.error js/console e))
-                                      (catch js/global.Error e
+                                      (catch :default e
                                         (.error js/console e)))))
                opts)]
     (MenuItem. (clj->js opts))))

--- a/src/lt/objs/opener.cljs
+++ b/src/lt/objs/opener.cljs
@@ -265,6 +265,5 @@
                                                                   (aget i)
                                                                   (.-path)))
                                   (recur (inc i)))))
-                            (catch js/Error e
-                              (println e)))
-                          ))
+                            (catch :default e
+                              (println e)))))

--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -782,10 +782,7 @@
                                 (try
                                   (load/js path true)
                                   (object/update! this [::loaded-files] #(conj (or % #{}) path))
-                                  (catch js/Error e
-                                    (.error js/console (str "Error loading JS file: " path " : " e))
-                                    (.error js/console (.-stack e)))
-                                  (catch js/global.Error e
+                                  (catch :default e
                                     (.error js/console (str "Error loading JS file: " path " : " e))
                                     (.error js/console (.-stack e)))))))))))
 

--- a/src/lt/objs/settings.cljs
+++ b/src/lt/objs/settings.cljs
@@ -22,10 +22,7 @@
   (when s
     (try
       (reader/read-string s)
-      (catch js/global.Error e
-        (console/error (str "Invalid settings file: " file "\n" e))
-        nil)
-      (catch js/Error e
+      (catch :default e
         (console/error (str "Invalid settings file: " file "\n" e))
         nil))))
 
@@ -163,9 +160,7 @@
     (do
       (try
         (object/refresh! (first objs))
-        (catch js/global.Error e
-          (.error js/console e))
-        (catch js/Error e
+        (catch :default e
           (.error js/console e)))
       (js/process.nextTick (fn []
                              (refresh-all (next objs)))))))

--- a/src/lt/objs/sidebar/workspace.cljs
+++ b/src/lt/objs/sidebar/workspace.cljs
@@ -169,7 +169,7 @@
                                   (object/raise workspace/current-ws :add.folder! path)
                                   (object/raise workspace/current-ws :add.file! path)))
                               (recur (inc i)))))
-                        (catch js/Error e
+                        (catch :default e
                           (println e)))))
 
 (behavior ::on-menu

--- a/src/lt/objs/tabs.cljs
+++ b/src/lt/objs/tabs.cljs
@@ -387,9 +387,7 @@
                       (try
                         (let [orig (:active-obj @this)]
                           (object/raise orig :close))
-                        (catch js/Error e
-                          (js/lt.objs.console.error e))
-                        (catch js/global.Error e
+                        (catch :default e
                           (js/lt.objs.console.error e)))))
 
 (behavior ::on-destroy-objs

--- a/src/lt/objs/workspace.cljs
+++ b/src/lt/objs/workspace.cljs
@@ -180,7 +180,7 @@
       (reconstitute ws (file->ws loc))
       (save ws (:file @ws))
       (files/delete! loc)
-      (catch js/Error e
+      (catch :default e
         ))))
 
 (defn cached []

--- a/src/lt/objs/workspace.cljs
+++ b/src/lt/objs/workspace.cljs
@@ -181,7 +181,7 @@
       (save ws (:file @ws))
       (files/delete! loc)
       (catch :default e
-        ))))
+        e))))
 
 (defn cached []
   (filter #(> (.indexOf % ".clj") -1) (files/full-path-ls workspace-cache-path)))


### PR DESCRIPTION
The 3386181 cleans up duplicate error handling as requested in #1996.
In the next commits I tried to do some cleaning in the catch-blocks themselves.
But I found a way too many catch-patterns :-(

```
(catch :default e
  (js/lt.objs.console.error e))

(catch :default e
  (console/error (str "Invalid settings file: " file "\n" e)))

(catch :default e
  (.error js/console e))

(catch :default e
  e)

(catch :default e
  (object/raise files-obj :files.open.error path e)
  (when cb (cb nil e)))

(catch :default e
  (when cb (cb nil)) nil)

(catch :default e
  (object/raise files-obj :files.save.error path e)
  (when cb (cb e)))

(catch :default e
  (object/raise files-obj :files.open.error path)
  nil)

(catch :default e
  (object/raise clients/clients :message [cb :editor.eval.cljs.exception {:ex e :meta (:meta res)}]))

(catch :default e
  (.error js/console (str "Error loading JS file: " path " : " e))
  (.error js/console (.-stack e)))

(catch :default e
  (console/error (str "Could not load behaviors for plugin: " (:name plug)))
  {})

(catch :default e
  (.log js/console "Error starting socket.io server" e))

(catch :default e
  (println e))

(catch :default e
  (safe-report-error (str "Invalid behavior: " (-> (->behavior r) :name)))
  (safe-report-error e))
```

It would be fine to have some try-catch guidelines so I could clean up these things too.