### PR TITLE
Add api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Prebuilt binaries are available through [lighttable.com](http://lighttable.com).
 * See the [community wiki](https://github.com/LightTable/LightTable/wiki) which includes a [User FAQ](https://github.com/LightTable/LightTable/wiki/FAQ) and a [For Users page](https://github.com/LightTable/LightTable/wiki/For-Users) for additional links.
 * For a typical Light Table workflow, [read this](doc/workflow.md).
 * To understand how Light Table works, read about its [BOT architecture](doc/BOT.md).
+* See [Light Table's API docs](http://lighttable.github.io/LightTable/api/index.html) to see what
+  plugin authors have access to.
 * If you're a user coming from vim or emacs see the [For Vim Users](https://github.com/LightTable/LightTable/wiki/For-Vim-Users) and [For Emacs Users](https://github.com/LightTable/LightTable/wiki/For-Emacs-Users) guides.
 
 ## Plugins

--- a/doc/for-committers.md
+++ b/doc/for-committers.md
@@ -62,3 +62,14 @@ This is our release checklist which can be dropped in to an issue:
       - [ ] Update download links on lighttable.com
       - [ ] Mailing list announcement - [example email](https://gist.github.com/cldwalker/3d67153fe1eade2ae3cf)
       - [ ] Optional blog post if a major release
+      - [ ] After release, [build api documentation](#build-api-documentation)
+
+## Build api documentation
+
+To build api documentation for current LT version and publish generated docs:
+
+1. In project.clj make sure that `[:codox :source-uri]` points to current LT version.
+   This step will be removed once [there is upstream support for version in :source-uri](https://github.com/weavejester/codox/issues/107)
+2. Run `script/build-api-docs.sh` on a clean git state. Make sure there are no pending git changes as this script will change git branches and push generated api docs to gh-pages.
+
+Expect to see a ton of warnings e.g. `WARNING: Use of undeclared Var cljs.core/seq at line 197`. This will be noise we have to live with until we upgrade ClojureScript.

--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
                                    :output-to "deploy/core/node_modules/lighttable/bootstrap.js"
                                    :output-dir "deploy/core/node_modules/lighttable/cljs/"
                                    :pretty-print true}}]}
+  ;; TODO: Remove separate :doc :dependencies after ClojureScript upgrade
   :profiles {:doc {:dependencies [[org.clojure/clojure "1.7.0"]
                                   [org.clojure/clojurescript "1.7.145"
                                    :exclusions [org.apache.ant/ant]]]}}

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject lighttable "0.8.0-alpha"
-  :description "Light Table is a new interactive IDE that lets you modify running programs and embed anything from websites to games. It provides the real time feedback we need to not only answer questions about our code, but to understand how our programs really work."
+  :description "Light Table is a next generation code editor that connects you to your creation with instant feedback. Light Table is very customizable and can display anything a Chromium browser can."
   :url "http://www.lighttable.com/"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [crate "0.2.5"]
@@ -28,6 +28,7 @@
                        lt.objs.editor.pool lt.objs.files lt.objs.notifos]
           ;; :source-uri version needs to be bumped per release until codox supports {version}
           :source-uri "https://github.com/LightTable/LightTable/blob/0.8.0-alpha/{filepath}#L{line}"
+          ;; Be explicit that undocumented public fns should be documented
           :metadata {:doc "TODO: Add docstring"}}
   :source-paths ["src/"]
   )

--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,19 @@
                                    :output-to "deploy/core/node_modules/lighttable/bootstrap.js"
                                    :output-dir "deploy/core/node_modules/lighttable/cljs/"
                                    :pretty-print true}}]}
-  :plugins [[lein-cljsbuild "1.0.1"]]
+  :profiles {:doc {:dependencies [[org.clojure/clojure "1.7.0"]
+                                  [org.clojure/clojurescript "1.7.145"
+                                   :exclusions [org.apache.ant/ant]]]}}
+  :plugins [[lein-cljsbuild "1.0.1"]
+            [lein-codox "0.9.0"]]
+  :codox {:language :clojurescript
+          :project {:name "LightTable"}
+          :output-path "codox"
+          :doc-paths [] ;; Disable including doc/
+          :namespaces [lt.macros lt.object lt.objs.command lt.objs.editor
+                       lt.objs.editor.pool lt.objs.files lt.objs.notifos]
+          ;; :source-uri version needs to be bumped per release until codox supports {version}
+          :source-uri "https://github.com/LightTable/LightTable/blob/0.8.0-alpha/{filepath}#L{line}"
+          :metadata {:doc "TODO: Add docstring"}}
   :source-paths ["src/"]
   )

--- a/script/build-api-docs.sh
+++ b/script/build-api-docs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# Build codox api docs and publish it on gh-pages branch
+
+lein with-profile doc codox
+
+git checkout gh-pages
+
+rm -rf api/
+mv codox api
+
+git add api
+git commit -m "Build api docs using script/build-api-docs.sh"
+git push origin gh-pages:gh-pages
+git checkout -

--- a/src/lt/macros.clj
+++ b/src/lt/macros.clj
@@ -36,7 +36,7 @@
          (lt.util.dom/on e# ev# func#))
        e#)))
 
-(defmacro timed [ev & body]
+(defmacro ^:private timed [ev & body]
   `(let [start# (lighttable.util.js/now)
          res# (do ~@body)]
      (lighttable.components.logger/log ~ev (- (lighttable.util.js/now) start#))
@@ -47,30 +47,30 @@
     [(first body) (rest body)]
     [[] body]))
 
-(defmacro on [name & body]
+(defmacro ^:private on [name & body]
   `(lighttable.command/on ~name (fn ~@body)))
 
-(defmacro in [ctx & body]
+(defmacro ^:private in [ctx & body]
   (let [[params body] (->params body)]
     `(assoc ~ctx :in (fn ~params ~@body))))
 
-(defmacro out [ctx & body]
+(defmacro ^:private out [ctx & body]
   (let [[params body] (->params body)]
     `(assoc ~ctx :out (fn ~params ~@body))))
 
-(defmacro defcontext [name & body]
+(defmacro ^:private defcontext [name & body]
   `(let [ctx# {:name ~name}]
      (lighttable.context/add-context!
        (-> ctx#
            ~@body))))
 
-(defmacro extract [elem kvs & body]
+(defmacro ^:private extract [elem kvs & body]
   (let [defs (vec (apply concat (for [[k v] (partition 2 kvs)]
                                   `[~k (lt.util.dom/$ ~v ~elem)])))]
     `(let ~defs
        ~@body)))
 
-(defmacro foreach [xs & body]
+(defmacro ^:private foreach [xs & body]
   `(let [xs# ~(second xs)
          len# (.-length xs#)]
      (loop [left# 0]
@@ -79,7 +79,7 @@
            ~@body
            (recur (inc left#)))))))
 
-(defmacro with-time [& body]
+(defmacro ^:private with-time [& body]
   (let [start (gensym "start")
         body (walk/postwalk-replace {'time (list '- '(.getTime (js/Date.)) start)} body)]
   `(let [~start (.getTime (js/Date.))]
@@ -98,7 +98,7 @@
         (.unshift args# (.-obj msg#))
         (.apply ~func nil args#)))))
 
-(defmacro aloop [[var arr] & body]
+(defmacro ^:private aloop [[var arr] & body]
   `(let [arr# ~arr]
      (loop [~var 0]
        (when (< ~var (.-length arr#))

--- a/src/lt/object.cljs
+++ b/src/lt/object.cljs
@@ -12,27 +12,27 @@
   (:require-macros [lt.macros :refer [behavior with-time aloop]]))
 
 ;; HEART of BOT Architecture!
-(def obj-id
+(def ^:private obj-id
   "Counter to guarantee unique object ids"
   (atom 0))
 
-(def instances
+(def ^:private instances
   "Map of object ids to objects created by object/create"
   (atom (sorted-map)))
 
-(def behaviors
+(def ^:private behaviors
   "Map of behavior names to behaviors created by macros/behavior"
   (atom {}))
 
-(def object-defs
+(def ^:private object-defs
   "Map of object template keys to template maps created by object/object*"
   (atom {}))
 
-(def tags
+(def ^:private tags
   "Map of tags to associated lists of behaviors"
   (atom {}))
 
-(def negated-tags
+(def ^:private negated-tags
   "Map of tags to dissociated lists of behaviors e.g. :-behavior"
   (atom {}))
 
@@ -287,7 +287,9 @@
   [obj & r]
   (swap! obj #(apply update-in % r)))
 
-(defn- assoc-in! [obj k v]
+(defn assoc-in!
+  "Update object with assoc-in for given key and value"
+  [obj k v]
   (when (and k (not (sequential? k)))
     (throw (js/Error. (str "Associate requires a sequence of keys: " k))))
   (swap! obj #(assoc-in % k v)))
@@ -356,11 +358,15 @@
   (raise* obj (trigger->behaviors :object.instant (:tags @obj)) nil)
   (raise obj :object.refresh))
 
-(defn- add-behavior! [obj behavior]
+(defn add-behavior!
+  "Add behavior to object and update its listeners"
+  [obj behavior]
   (update! obj [:behaviors] conj behavior)
   (reset! obj (update-listeners obj)))
 
-(defn- rem-behavior! [obj behavior]
+(defn rem-behavior!
+  "Remove behavior from object and update its listeners"
+  [obj behavior]
   (update! obj [:behaviors] #(remove #{behavior} %))
   (reset! obj (update-listeners obj)))
 

--- a/src/lt/object.cljs
+++ b/src/lt/object.cljs
@@ -46,7 +46,9 @@
 (defn- add-behavior [beh]
   (swap! behaviors assoc (:name beh) beh))
 
-(defn ->id [obj]
+(defn ->id
+  "Return id of given object"
+  [obj]
   (if (deref? obj)
     (::id @obj)
     (::id obj)))
@@ -384,17 +386,25 @@
 (defn- in-tag? [tag behavior]
   (first (filter #{behavior} (@tags tag))))
 
-(defn has-tag? [obj tag]
+(defn has-tag?
+  "Return truthy if object has tag"
+  [obj tag]
   ((:tags @obj) tag))
 
-(defn add-tags [obj ts]
+(defn add-tags
+  "Add tags to given object and updates effected behaviors and listeners.
+  ::tags-added trigger is raised on object after update"
+  [obj ts]
   (update! obj [:tags] #(reduce conj % (filter identity ts)))
   (reset! obj (update-listeners obj))
   (raise obj ::tags-added ts)
   (raise* obj (trigger->behaviors :object.instant ts) nil)
   obj)
 
-(defn remove-tags [obj ts]
+(defn remove-tags
+  "Remove tags from given object and updates effected behaviors and listeners.
+  ::tags-removed trigger is raised on object after update"
+  [obj ts]
   (let [cur @obj
         behs (apply concat (map @tags ts))
         cur (-> cur

--- a/src/lt/objs/command.cljs
+++ b/src/lt/objs/command.cljs
@@ -4,7 +4,7 @@
 
 (declare manager)
 
-(def required-keys #{:command :desc :exec})
+(def ^:private required-keys #{:command :desc :exec})
 
 (defn command
   "Define a command given a map with the following keys:
@@ -21,12 +21,12 @@
     (object/add-tags (:options cmd) [:command.options]))
   (object/raise manager :added cmd))
 
-(defn by-id [k]
+(defn- by-id [k]
   (-> @manager :commands (get (if (map? k)
                                 (:command k)
                                 k))))
 
-(defn completions [token]
+(defn- completions [token]
   (if (and token
            (= (subs token 0 1) ":"))
     (map #(do #js {:completion (str (:command %)) :text (str (:command %))}) (vals (:commands @manager)))
@@ -53,4 +53,4 @@
                 :tags #{:command.manager}
                 :commands {})
 
-(def manager (object/create ::command.manager))
+(def ^:private manager (object/create ::command.manager))

--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -58,7 +58,7 @@
 ;; commands
 ;;*********************************************************
 
-(defn expand-tab [cm]
+(defn- expand-tab [cm]
   (cond
    (.somethingSelected cm) (.indentSelection cm "add")
    (.getOption cm "indentWithTabs") (.replaceSelection cm "\t" "end" "+input")
@@ -71,11 +71,11 @@
 ;; Creating
 ;;*********************************************************
 
-(defn headless [opts]
+(defn- headless [opts]
   (-> (js/CodeMirror. (fn []))
       (set-options opts)))
 
-(defn make [context]
+(defn- make [context]
   (let [e (headless {:mode (if (:mime context)
                              (name (:mime context))
                              "plaintext")
@@ -102,7 +102,7 @@
   [ed ev func]
   (.off (->cm-ed ed) (name ev) func))
 
-(defn wrap-object-events [ed obj]
+(defn- wrap-object-events [ed obj]
   (dom/on (->elem ed) :contextmenu #(object/raise obj :menu! %))
   (on ed :dragstart #(.preventDefault %2))
   (on ed :dragenter #(.preventDefault %2))
@@ -125,23 +125,23 @@
   [e]
   (. (->cm-ed e) (getValue)))
 
-(defn ->token [e pos]
+(defn- ->token [e pos]
   (js->clj (.getTokenAt (->cm-ed e) (clj->js pos)) :keywordize-keys true))
 
-(defn ->token-js [e pos]
+(defn- ->token-js [e pos]
   (.getTokenAt (->cm-ed e) (clj->js pos)))
 
-(defn ->token-type [e pos]
+(defn- ->token-type [e pos]
   (.getTokenTypeAt (->cm-ed e) (clj->js pos)))
 
-(defn ->coords [e]
+(defn- ->coords [e]
   (js->clj (.cursorCoords (->cm-ed e)) :keywordize-keys true :force-obj true))
 
-(defn +class [e klass]
+(defn- +class [e klass]
   (add-class (->elem e) (name klass))
   e)
 
-(defn -class [e klass]
+(defn- -class [e klass]
   (remove-class (->elem e) (name klass))
   e)
 
@@ -417,7 +417,7 @@
   ([e loc]
    (.foldCode (->cm-ed e) (clj->js loc))))
 
-(defn gutter-widths [e]
+(defn- gutter-widths [e]
   (let [gutter-div (dom/$ :div.CodeMirror-gutters (object/->content e))
         gutter-divs (dom/$$ :div.CodeMirror-gutter gutter-div)
         current-widths (reduce (fn [res gutter]
@@ -426,7 +426,7 @@
                                  ) {} gutter-divs)]
     current-widths))
 
-(defn update-gutters [e class-names class-widths]
+(defn- update-gutters [e class-names class-widths]
   (let [gutter-div (dom/$ :div.CodeMirror-gutters (object/->content e))]
     (operation e (fn[]
                    (set-options e {:gutters (clj->js class-names)})

--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -125,13 +125,13 @@
   [e]
   (. (->cm-ed e) (getValue)))
 
-(defn- ->token [e pos]
+(defn ->token [e pos]
   (js->clj (.getTokenAt (->cm-ed e) (clj->js pos)) :keywordize-keys true))
 
 (defn- ->token-js [e pos]
   (.getTokenAt (->cm-ed e) (clj->js pos)))
 
-(defn- ->token-type [e pos]
+(defn ->token-type [e pos]
   (.getTokenTypeAt (->cm-ed e) (clj->js pos)))
 
 (defn- ->coords [e]

--- a/src/lt/objs/editor/pool.cljs
+++ b/src/lt/objs/editor/pool.cljs
@@ -42,7 +42,9 @@
 (object/object* ::pool
                 :tags #{:editor.pool})
 
-(defn unsaved? []
+(defn unsaved?
+  "Return truthy if any editors are currently dirty/unsaved?"
+  []
   (some #(:dirty (deref %)) (object/by-tag :editor)))
 
 (defn by-path
@@ -210,7 +212,9 @@
                             (doc/move-doc old neue-path)
                             )))))
 
-(defn create [info]
+(defn create
+  "Create a :lt.objs.editor/editor object with given info map and add it to current pool"
+  [info]
   (let [ed (object/create :lt.objs.editor/editor info)]
     (object/add-tags ed (:tags info []))
     (object/merge! ed {:editor.generation (editor/->generation ed)})

--- a/src/lt/objs/editor/pool.cljs
+++ b/src/lt/objs/editor/pool.cljs
@@ -15,7 +15,7 @@
             [lt.util.dom :as dom])
   (:require-macros [lt.macros :refer [behavior defui]]))
 
-(defn get-all []
+(defn- get-all []
   (object/by-tag :editor))
 
 (behavior ::theme-changed
@@ -58,20 +58,20 @@
   (let [path (string/lower-case path)]
     (filter #(> (.indexOf (-> @% :info :path (or "") string/lower-case) path) -1) (object/by-tag :editor))))
 
-(defui button [label & [cb]]
+(defui ^:private button [label & [cb]]
   [:div.button.right label]
   :click (fn []
            (when cb
              (cb))))
 
-(defn unsaved-prompt [on-yes]
+(defn- unsaved-prompt [on-yes]
   (popup/popup! {:header "You will lose changes."
                  :body "If you close now, you'll lose any unsaved changes. Are you sure you want to do that?"
                  :buttons [{:label "Discard changes"
                             :action on-yes}
                            popup/cancel-button]}))
 
-(def pool (object/create ::pool))
+(def ^:private pool (object/create ::pool))
 
 (defn last-active
   "Return current editor object (last active in pool)"
@@ -80,7 +80,7 @@
     (when (and l @l)
       l)))
 
-(defn focus-last []
+(defn- focus-last []
   (when-let [ed (last-active)]
     (when-let [ed (:ed @ed)]
       (dom/focus js/document.body)
@@ -117,18 +117,18 @@
           :reaction (fn [this]
                       (focus-last)))
 
-(defn make-transient-dirty [ed]
+(defn- make-transient-dirty [ed]
   (object/merge! ed {:dirty true})
   (object/update! ed [:info] assoc :path nil)
   (object/remove-tags ed [:editor.file-backed])
   (object/add-tags ed [:editor.transient]))
 
-(defn active-warn [ed popup]
+(defn- active-warn [ed popup]
   (if-not (= (last-active) ed)
     (object/merge! ed {:active-warn popup})
     (popup/popup! popup)))
 
-(defn reload [ed]
+(defn- reload [ed]
   (editor/set-val ed (:content (files/open-sync (-> @ed :info :path))))
   (doc/update-stats (-> @ed :info :path))
   (object/merge! ed {:dirty false}))
@@ -156,7 +156,7 @@
                                                          ]})
                               (reload ed)))))))
 
-(defn warn-delete [ed f]
+(defn- warn-delete [ed f]
   (active-warn ed {:header (str "File deleted: " f)
                    :body "This file seems to have been deleted and we've marked it as unsaved."
                    :buttons [{:label "Save as.."
@@ -164,7 +164,7 @@
                                         (object/raise ed :save))}
                              {:label "ok"}]}))
 
-(defn set-syntax [ed new-syn]
+(defn- set-syntax [ed new-syn]
   (let [prev-info (-> @ed :info)]
     (when prev-info
       (object/remove-tags ed (:tags prev-info)))
@@ -172,7 +172,7 @@
     (editor/set-mode ed (:mime new-syn))
     (object/add-tags ed (:tags new-syn))))
 
-(defn set-syntax-by-path [ed path]
+(defn- set-syntax-by-path [ed path]
   (set-syntax ed (files/path->type path)))
 
 (behavior ::watched.delete
@@ -225,10 +225,10 @@
                       (focus-last))})
 
 
-(def syntax-selector (cmd/filter-list {:items (fn []
-                                                (sort-by :name (-> @files/files-obj :types vals)))
-                                       :key :name
-                                       :placeholder "Syntax"}))
+(def ^:private syntax-selector (cmd/filter-list {:items (fn []
+                                                          (sort-by :name (-> @files/files-obj :types vals)))
+                                                 :key :name
+                                                 :placeholder "Syntax"}))
 
 (behavior ::set-syntax
           :triggers #{:select}
@@ -265,7 +265,7 @@
           :reaction (fn [this options]
                       (object/merge! this {::comment-options options})))
 
-(defn do-commenting [commenting-fn]
+(defn- do-commenting [commenting-fn]
   (when-let [cur (last-active)]
     (let [from (editor/->cursor cur "start")
           to (if (editor/selection? cur)

--- a/src/lt/objs/files.cljs
+++ b/src/lt/objs/files.cljs
@@ -56,8 +56,8 @@
                                                         :exts {}
                                                         :types {})))
 
-(def line-ending (.-EOL os))
-(def separator (.-sep fpath))
+(def line-ending "Current platform-specific line" (.-EOL os))
+(def separator "Current platform-specific file separator" (.-sep fpath))
 (def ^:private available-drives #{})
 (def cwd "Directory process is started in" (js/process.cwd))
 

--- a/src/lt/objs/notifos.cljs
+++ b/src/lt/objs/notifos.cljs
@@ -7,15 +7,15 @@
             [crate.binding :refer [map-bound bound deref?]])
   (:require-macros [lt.macros :refer [behavior defui]]))
 
-(def standard-timeout 10000)
+(def ^:private standard-timeout 10000)
 
-(defn msg* [m & [opts]]
+(defn- msg* [m & [opts]]
   (let [m (if (string? m)
             m
             (pr-str m))]
     (object/merge! statusbar/statusbar-loader (merge {:message m :class ""} opts))))
 
-(declare cur-timeout)
+(def ^:private cur-timeout)
 
 (defn set-msg!
   "Display message in bottom statusbar. Takes map of options with following keys:


### PR DESCRIPTION
This adds API docs for LightTable building off of https://github.com/LightTable/LightTable/commit/f94bf3af0d382424c69161d5b01680d0ea657a38 so we can encourage plugin authors and more users to read and understand the code base. I've included a script and documentation for publishing these docs. [Here is what the current docs look like](http://lighttable.github.io/LightTable/api/lt.macros.html). The styling isn't amazing but I'm ok with for a first pass. I did have to mark some fns private and added a few more docstring for public fns. I limited docs to a few namespaces as covered in #1955. I'm open to adding more down the road.

There weren't too many choices when choosing between libraries that generate documentation for cljs projects: I only found codox and marginalia. I chose codox because only it supported links to fns e.g. [object/add-tags](http://lighttable.github.io/LightTable/api/lt.object.html#var-add-tags) and I think it's important to encourage conversation around docs.

@rundis @kenny-evitt Would like to get this merged before our release