### PR TITLE
fix first-time build to not require bootstrap.js to exist

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -31,7 +31,12 @@ popd
 if [ "$(echo $(uname -s) | cut -c 1-9)" == "CYGWIN_NT" ]; then
   sed -i 's/:source-map/;;:source-map/' project.clj
 fi
-rm deploy/core/node_modules/lighttable/bootstrap.js && lein cljsbuild once app
+
+bsjs=deploy/core/node_modules/lighttable/bootstrap.js
+if [ -e "$bsjs" ]; then
+  rm "$bsjs" || { echo >&2 "Unable to delete existing $bsjs"; exit 1; }
+fi
+lein cljsbuild once app
 
 # Fetch plugins
 PLUGINS=("Clojure,0.2.0" "CSS,0.0.6" "HTML,0.1.0" "Javascript,0.1.3"


### PR DESCRIPTION
Otherwise a first-time build seems to succeed but silently fails and hangs at start