### PR TITLE
Avoid opening a nonexistent file and logging error

### DIFF
--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -96,21 +96,22 @@
       plugin)))
 
 (defn plugin-edn [dir]
-  (when-let [content (files/open-sync (files/join dir "plugin.edn"))]
-    (try
-      (-> (EOF-read (:content content))
-          (assoc :dir dir)
-          (validate "plugin.edn"))
-      (catch :default e
-        (console/error (str "FAILED to load plugin.edn: " dir))))
-    ))
+  (let [file (files/join dir "plugin.edn")]
+    (when-let [content (and (files/exists? file) (files/open-sync file))]
+      (try
+        (-> (EOF-read (:content content))
+            (assoc :dir dir)
+            (validate "plugin.edn"))
+        (catch :default e
+          (console/error (str "FAILED to load plugin.edn: " dir)))))))
 
 (defn plugin-json [dir]
-  (when-let [content (files/open-sync (files/join dir "plugin.json"))]
-    (-> (js/JSON.parse (:content content))
-        (js->clj :keywordize-keys true)
-        (assoc :dir dir)
-        (validate "plugin.json"))))
+  (let [file (files/join dir "plugin.json")]
+    (when-let [content (and (files/exists? file) (files/open-sync file))]
+      (-> (js/JSON.parse (:content content))
+          (js->clj :keywordize-keys true)
+          (assoc :dir dir)
+          (validate "plugin.json")))))
 
 (defn plugin-info [dir]
   (or (plugin-json dir) (plugin-edn dir)))


### PR DESCRIPTION
When saving clojure.cljs in the Clojure and rebuilding a plugin's clojurescript, we are
unnecessarily opening nonexistent files. We didn't notice this before because we weren't logging those errors until dffe186953b6be27b7ba1ee402d8bc0a94f6626f e.g. `Failed to open path '/Users/me/Library/Application Support/LightTable/plugins/Clojure/plugin.json' with error:`. I searched the rest of the code base and didnt' find any other uses of files/open-* that were effected in a similar way. Will merge this tomorrow unless there are any concerns