### PR TITLE
Handle invalid tags and metadata-commits responses

### DIFF
--- a/src/lt/objs/deploy.cljs
+++ b/src/lt/objs/deploy.cljs
@@ -131,11 +131,15 @@
 (defn ->latest-version
   "Returns latest LT version for github api tags endpoint."
   [body]
-  (->> (js/JSON.parse body)
-       ;; Ensure only version tags
-       (keep #(when (re-find version-regex (.-name %)) (.-name %)))
-       sort
-       last))
+  (when-let [parsed-body
+             (try (js/JSON.parse body)
+               (catch :default e
+                 (console/error (str "Invalid JSON response from " tags-url ": " (pr-str body)))))]
+    (->> parsed-body
+         ;; Ensure only version tags
+         (keep #(when (re-find version-regex (.-name %)) (.-name %)))
+         sort
+         last)))
 
 (defn check-version [& [notify?]]
   (fetch/xhr tags-url {}

--- a/src/lt/objs/plugins.cljs
+++ b/src/lt/objs/plugins.cljs
@@ -222,10 +222,12 @@
 (defn latest-metadata-sha []
   (fetch/xhr [:get metadata-commits] {}
              (fn [data]
-               (let [parsed (js/JSON.parse data)
-                     sha (-> (aget parsed 0)
-                             (aget "sha"))]
-                 (object/raise manager :metadata.sha sha)))))
+               (when-let [parsed (try (js/JSON.parse data)
+                                   (catch :default e
+                                     (console/error (str "Invalid JSON response from " metadata-commits ": " (pr-str data)))))]
+                 (let [sha (-> (aget parsed 0)
+                               (aget "sha"))]
+                   (object/raise manager :metadata.sha sha))))))
 
 (defn download-metadata [sha]
   (let [tmp-gz (files/lt-user-dir "metadata-temp.tar.gz")


### PR DESCRIPTION
This fixes #2026. I was able to consistently reproduce the error by turning off the internet connection
and starting LightTable. Now when a user experiences this error, they see:
```
Invalid JSON response from https://api.github.com/repos/LightTable/LightTable/tags: ""
Failed to load resource: net::ERR_INTERNET_DISCONNECTED: https://api.github.com/repos/LightTable/LightTable/tags
```
The first commit explains why we can't detect on response code and I think this is a reasonable solution given the time spent on it. I also searched for other similar uses of fetch/xhr  and found the plugin manager would cause the same error when the network was off.
@rundis @kenny-evitt I'll merge tomorrow unless there are any concerns