### PR TITLE
#2003 Add behaviors to enable/disable edit/closebrackets.js addon.

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -195,6 +195,7 @@
  [:editor :lt.objs.editor/hide-line-numbers]
  [:editor :lt.objs.editor/hide-fold-gutter]
  [:editor :lt.objs.editor/no-wrap]
+ [:editor :lt.objs.editor/disable-brackets-autoclose]
  [:editor :lt.objs.settings/default-keymap-diffs]
  [:editor :lt.objs.settings/user-keymap-diffs]
  [:editor :lt.objs.settings/default-behavior-diffs]

--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -702,6 +702,7 @@
           :triggers #{:init}
           :reaction (fn [this]
                       (load/js "core/node_modules/codemirror/addon/edit/matchbrackets.js" :sync)
+                      (load/js "core/node_modules/codemirror/addon/edit/closebrackets.js" :sync)
                       (load/js "core/node_modules/codemirror/addon/comment/comment.js" :sync)
                       (load/js "core/node_modules/codemirror/addon/selection/active-line.js" :sync)
                       ;; TODO: use addon/mode/overlay.js
@@ -749,3 +750,19 @@
                         (load/js "core/node_modules/codemirror/addon/display/rulers.js" :sync))
                       (let [rulers (or rulers [{:lineStyle "dashed" :color "#aff" :column 80}])]
                         (set-options this {:rulers (clj->js rulers)}))))
+
+(behavior ::enable-brackets-autoclose
+          :triggers #{:object.instant :lt.object/tags-removed}
+          :desc "Editor: Enable brackets autoclose"
+          :exclusive [::disable-brackets-autoclose]
+          :type :user
+          :reaction (fn [this]
+                      (set-options this {:autoCloseBrackets true})))
+
+(behavior ::disable-brackets-autoclose
+          :triggers #{:object.instant :lt.object/tags-removed}
+          :desc "Editor: Disable brackets autoclose"
+          :exclusive [::enable-brackets-autoclose]
+          :type :user
+          :reaction (fn [this]
+                      (set-options this {:autoCloseBrackets false})))

--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -756,8 +756,12 @@
           :desc "Editor: Enable brackets autoclose"
           :exclusive [::disable-brackets-autoclose]
           :type :user
-          :reaction (fn [this]
-                      (set-options this {:autoCloseBrackets true})))
+          :params [{:label "map"
+                    :example "{:pairs \"()[]{}''\\\"\\\"\" :explode \"[]{}\"}"}]
+          :reaction (fn [this opts]
+                      (if opts
+                        (set-options this {:autoCloseBrackets (clj->js opts)})
+                        (set-options this {:autoCloseBrackets true}))))
 
 (behavior ::disable-brackets-autoclose
           :triggers #{:object.instant :lt.object/tags-removed}


### PR DESCRIPTION
Add enable/disable behaviors codemirror edit/closebrackets.js addon, that fix pairs autocomplete for international keyboards.

For more information see #2003  