### PR TITLE
Improve usability with git and any other vcs

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -180,7 +180,6 @@
  [:editor :lt.objs.editor.pool/track-active]
  [:editor :lt.objs.editor.pool/ed-close]
  [:editor :lt.objs.editor/menu!]
- [:editor :lt.objs.editor.pool/warn-on-active]
  [:editor :lt.objs.editor/refresh!]
  [:editor :lt.objs.editor.pool/line-comment-options {}]
  [:editor :lt.plugins.auto-paren/repeat-pair]

--- a/src/lt/objs/document.cljs
+++ b/src/lt/objs/document.cljs
@@ -166,7 +166,7 @@
                          (cb d))))))
 
 (defn check-mtime [prev updated]
-  (if prev
+  (if (and prev updated)
     (= (.getTime (.-mtime prev)) (.getTime (.-mtime updated)))
     true))
 


### PR DESCRIPTION
This fixes #942 and #1720 - usability issues with files being modified and deleted when doing git (or any vcs) operations outside LightTable. Previously, when a file was modified or deleted externally, we would display a popup on each tab and display multiple popups on each tab for each time the file was modified. This was painful as switching or merging branches often led to clicking on a number of dialogs. The new behavior mimics Atom which I think is more friendly and intuitive. The new behavior for a modified file with unsaved changes is to leave the tab as is. As explained in the commit, a user will still get a dialog on save which prevents accidental overwrite. The new behavior for a deleted file is to remove its tab if there are no unsaved changes and to leave the tab as is if there are unsaved changes. @rundis @kenny-evitt I'll merge on Tuesday unless there are concerns