### PR TITLE
Fix editor save behaviors

### DIFF
--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -29,9 +29,18 @@
   [e]
   (.-parentElement (.getScrollerElement (->cm-ed e))))
 
-(defn set-val [e v]
+(defn set-val
+  "Set content value of editor's CodeMirror object. Cursor position is lost"
+  [e v]
   (. (->cm-ed e) (setValue (or v "")))
   e)
+
+(defn set-val-and-keep-cursor
+  "Same as set-val but current cursor position is kept"
+  [e v]
+  (let [cursor (.getCursor (->cm-ed e))]
+    (set-val e v)
+    (.setCursor (->cm-ed e) cursor)))
 
 (defn set-options
   "Given a map of options, set each pair as an option on editor's

--- a/src/lt/objs/editor/file.cljs
+++ b/src/lt/objs/editor/file.cljs
@@ -14,14 +14,15 @@
           :reaction (fn [editor]
                       (let [{:keys [path]} (@editor :info)
                             final (object/raise-reduce editor :save+ (ed/->val editor))]
+                        (when (not= final (ed/->val editor))
+                          (ed/set-val-and-keep-cursor editor final))
                         (doc/save path final
                                   (fn []
                                     (object/merge! editor {:dirty false
                                                            :editor.generation (ed/->generation editor)})
                                     (object/raise editor :saved)
-                                    (object/raise editor :clean)
-                                    ;;TODO: saved
-                                    )))))
+                                    ;; TODO: :clean trigger unused internally. Consider removing
+                                    (object/raise editor :clean))))))
 
 (behavior ::dirty-on-change
           :throttle 100

--- a/src/lt/objs/editor/pool.cljs
+++ b/src/lt/objs/editor/pool.cljs
@@ -131,7 +131,7 @@
     (popup/popup! popup)))
 
 (defn- reload [ed]
-  (editor/set-val ed (:content (files/open-sync (-> @ed :info :path))))
+  (editor/set-val-and-keep-cursor ed (:content (files/open-sync (-> @ed :info :path))))
   (doc/update-stats (-> @ed :info :path))
   (object/merge! ed {:dirty false}))
 


### PR DESCRIPTION
As pointed out in #1733, there is a bug where the tab doesn't update when trailing whitespace is removed. Fix involved adding a new editor function as CodeMirror's setValue doesn't keep cursor position. Also fixed a related bug where cursor position always jumped when file was modified outside LT. Now there's a fix where cursor position is kept for cases explained in commit. To QA, open a file, move cursor somewhere, `touch FILE` in terminal and observe cursor stay put.

@rundis @kenny-evitt Merging tomorrow night unless there are any concerns