### PR TITLE
Make docs navigable by opening in a browser tab - close #1097

### DIFF
--- a/deploy/core/css/skins/new-dark.css
+++ b/deploy/core/css/skins/new-dark.css
@@ -521,19 +521,6 @@ input {
   background: #606970;
   border: 1px solid #606970;
 }
-.docs ::-webkit-scrollbar {
-  background: #3b3f41 !important;
-}
-.docs ::-webkit-scrollbar-track {
-  background: #3b3f41 !important;
-}
-.docs ::-webkit-scrollbar-corner {
-  background: #3b3f41 !important;
-}
-.docs ::-webkit-scrollbar-thumb {
-  background: #606970;
-  border: 1px solid #606970;
-}
 .search-results .path,
 .search-results .line {
   color: #bbb;

--- a/deploy/core/css/skins/new-dark.stylus
+++ b/deploy/core/css/skins/new-dark.stylus
@@ -235,11 +235,6 @@ input { color: $highlight-fg; background:$highlight-bg; }
 #browser ::-webkit-scrollbar-corner { background: $bg !important; }
 #browser ::-webkit-scrollbar-thumb { background: $scrollbar; border:1px solid $scrollbar;  }
 
-.docs ::-webkit-scrollbar { background: $bg !important; }
-.docs ::-webkit-scrollbar-track { background: $bg !important; }
-.docs ::-webkit-scrollbar-corner { background: $bg !important; }
-.docs ::-webkit-scrollbar-thumb { background: $scrollbar; border:1px solid $scrollbar;  }
-
 .search-results .path, .search-results .line { color:$hidden-fg; }
 .search-results .line { color:$secondary-accent-desat-fg; }
 .search-results .entry { color: $placeholder-fg; }

--- a/deploy/core/css/structure.css
+++ b/deploy/core/css/structure.css
@@ -294,11 +294,6 @@ body { -webkit-user-select: none; }
 #find-bar input { display:inline-block; font-size:11pt; font-family:"Inconsolata", "Ubuntu Mono", "Consolas", monospace; border-radius:0;  width:50%; height:30px; box-sizing:border-box; padding:5px; padding-left:10px; outline:none; }
 #find-bar button { position:absolute; right:-3px; z-index: 100000; padding:6px 10px;}
 
-
-.docs { width:100%; height:100%; }
-.docs iframe { width:100%; height:100%; }
-.docs .frame-shade { height:100%; width:100%; background:transparent; position:absolute; display:none; }
-
 #browser webview { position:absolute; top:0; left:0; right:0; bottom:35px; }
 #browser nav { position:absolute; bottom:5px; left:0; right:0; }
 #browser .frame-shade { height:-webkit-calc(100% - 35px); width:100%; background:transparent; position:absolute; display:none; }

--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -155,8 +155,6 @@
  [:docable :lt.plugins.doc/editor.doc.show!]
  [:docable :lt.plugins.doc/doc-menu+]
 
- [:docs :lt.objs.docs/on-close-destroy]
-
  [:document :lt.objs.document/try-close-root-document]
  [:document :lt.objs.document/close-root-document]
  [:document :lt.objs.document/set-linked-doc-options {}]

--- a/src/lt/objs/docs.cljs
+++ b/src/lt/objs/docs.cljs
@@ -1,46 +1,8 @@
 (ns lt.objs.docs
-  "Provide command and behavior(s) to see LT documentation"
-  (:require [lt.object :as object]
-            [lt.objs.command :as cmd]
-            [lt.objs.tabs :as tabs])
-  (:require-macros [lt.macros :refer [behavior]]))
-
-;;*********************************************************
-;; Object
-;;*********************************************************
-
-(object/object* ::docs
-                :tags #{:docs}
-                :name "Docs"
-                :init (fn [this]
-                        [:div.docs
-                         [:div.frame-shade]
-                         [:iframe {:src "http://docs.lighttable.com" :nwdisable "true" :nwfaketop "true"}]]))
-
-;;*********************************************************
-;; Behaviors
-;;*********************************************************
-
-(behavior ::on-close-destroy
-                  :triggers #{:close}
-                  :reaction (fn [this]
-                              (when-let [ts (:lt.objs.tabs/tabset @this)]
-                                (when (= (count (:objs @ts)) 1)
-                                  (tabs/rem-tabset ts)))
-                              (object/raise this :destroy)))
-
-;;*********************************************************
-;; Commands
-;;*********************************************************
+  "Provide command to see LT documentation"
+  (:require [lt.objs.command :as cmd]))
 
 (cmd/command {:command :show-docs
               :desc "Docs: Open Light Table's documentation"
               :exec (fn []
-                      (if (empty? (object/by-tag :docs))
-                        (let [docs (object/create ::docs)
-                              ts (tabs/spawn-tabset)]
-                          (tabs/equalize-tabset-widths)
-                          (tabs/add! docs ts)
-                          (tabs/active! docs))
-                        (let [docs (first (object/by-tag :docs))]
-                          (tabs/add-or-focus! docs))))})
+                      (cmd/exec! :add-browser-tab "http://docs.lighttable.com/"))})


### PR DESCRIPTION
Agree that documentation should have navigation so moved it into a browser tab. Removed a bunch of custom code around setting up and styling a custom doc iframe. Documentation no longer opens in a tabset as it was buggy and I don't think provided much value. Before the change:

<img width="1440" alt="screen shot 2016-01-08 at 12 23 31 am" src="https://cloud.githubusercontent.com/assets/11994/12191110/80b9c2c2-b59e-11e5-8656-2029c899e91c.png">

After the change - looks the same but is much more usable:

<img width="1440" alt="screen shot 2016-01-08 at 12 22 04 am" src="https://cloud.githubusercontent.com/assets/11994/12191121/96aa4822-b59e-11e5-9e02-5eda18f1d1d5.png">

The doc namespace is just the command but I couldn't think of somewhere else to put it. 

@kenny-evitt @rundis I'll merge Saturday unless there are any concerns
