### PR TITLE
Font settings is global, not editor specific - #1460

### DIFF
--- a/src/lt/objs/style.cljs
+++ b/src/lt/objs/style.cljs
@@ -54,7 +54,7 @@
                               ))
 
 (behavior ::font-settings
-                  :desc "Editor: Font settings"
+                  :desc "App: Font settings"
                   :params [{:label "Font family"
                             :type :string}
                            {:label "Size (pt)"


### PR DESCRIPTION
Users have been mislead in #1460 and #1045 by "Editor:" in the font-settings behavior description. Changing to "App: " makes it clear this is global. Will merge this later today unless there's a concern