### PR TITLE
Allow case sensitive renaming - close #1352

### DIFF
--- a/src/lt/objs/files.cljs
+++ b/src/lt/objs/files.cljs
@@ -243,13 +243,7 @@
 (defn move!
   "Move file or directory to given path"
   [from to]
-  (if (dir? from)
-    (do
-      (.copyDirSyncRecursive wrench from to)
-      (.rmdirSyncRecursive wrench from))
-    (do
-      (save to (:content (open-sync from)))
-      (delete! from))))
+  (.renameSync fs from to))
 
 (defn copy
   "Copy file or directory to given path"

--- a/src/lt/objs/sidebar/workspace.cljs
+++ b/src/lt/objs/sidebar/workspace.cljs
@@ -290,7 +290,8 @@
                       (let [path (:path @this)
                             neue (files/join (files/parent path) n)]
                         (when-not (= path neue)
-                          (if (files/exists? neue)
+                          ;; In OSX rename is case-sensistive but exists check isn't
+                          (if (and (not= (string/lower-case path) (string/lower-case neue)) (files/exists? neue))
                             (popup/popup! {:header "Folder already exists."
                                            :body (str "The folder " neue " already exists, you'll have to pick a different name.")
                                            :buttons [{:label "ok"
@@ -312,7 +313,8 @@
                       (let [path (:path @this)
                             neue (files/join (files/parent path) n)]
                         (when-not (= path neue)
-                          (if (files/exists? neue)
+                          ;; In OSX rename is case-sensistive but exists check isn't
+                          (if (and (not= (string/lower-case path) (string/lower-case neue)) (files/exists? neue))
                             (popup/popup! {:header "File already exists."
                                            :body (str "The file" neue " already exists, you'll have to pick a different name.")
                                            :buttons [{:label "ok"


### PR DESCRIPTION
Latest fs has a rename that is case sensitive. Exists check wasn't case sensitive on osx but able
to work around that by checking if case differs

@rundis @kenny-evitt Will merge later today unless there's a concern