### PR TITLE
Just have a toggle connect command - close #1167

### DIFF
--- a/deploy/settings/default/default.keymap
+++ b/deploy/settings/default/default.keymap
@@ -73,7 +73,7 @@
 
  [:searcher.search "enter" :searcher.search]
 
- [:sidebar.clients "esc" :hide-connect]
+ [:sidebar.clients "esc" :show-connect]
 
  [:sidebar.doc.search.input "esc" :docs.search.hide]
  [:sidebar.doc.search.input "enter" :docs.search.exec]

--- a/src/lt/objs/sidebar/clients.cljs
+++ b/src/lt/objs/sidebar/clients.cljs
@@ -163,18 +163,10 @@
   (object/update! clients [:connectors] assoc (:name c) c))
 
 (cmd/command {:command :show-connect
-              :desc "Connect: Show connect bar"
+              :desc "Connect: Toggle connect bar"
               :exec (fn []
                       (object/raise sidebar/rightbar :toggle clients)
-                      (object/raise clients :focus!)
-                      )})
-
-
-(cmd/command {:command :hide-connect
-              :desc "Connect: hide connect bar"
-              :exec (fn []
-                      (object/raise sidebar/rightbar :close!)
-                      )})
+                      (object/raise clients :focus!))})
 
 (cmd/command {:command :show-add-connection
               :desc "Connect: Add Connection"


### PR DESCRIPTION
:show-connect command is a toggle command. Removed :hide-connect since
that command closes the connection bar correctly in the only context
it's used. It's tempting to rename :show-connect to :toggle-connect but I didn't want to cause any command breakages.

@kenny-evitt @rundis Merging tomorrow unless there are concerns