### PR TITLE
Quote `which` command in build script

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -8,13 +8,13 @@ set -e
 # the app before calling build-app.sh to build it.
 
 # Check if lein is installed
-[ `which lein` ] || { echo >&2 "Please install leiningen before running this script."; exit 1; }
+[ "`which lein`" ] || { echo >&2 "Please install leiningen before running this script."; exit 1; }
 if [ "$(echo `lein version` | grep 'Leiningen \(1.\|2.0\)')" ]; then
   echo "lein version must be 2.1 or above. Do a lein upgrade first"; exit 1;
 fi
 
 # Check if npm is installed
-[ `which npm` ] || { echo >&2 "Please install npm before running this script."; exit 1; }
+[ "`which npm`" ] || { echo >&2 "Please install npm before running this script."; exit 1; }
 
 # Ensure we start in project root
 cd "$(dirname "${BASH_SOURCE[0]}")"; cd ..


### PR DESCRIPTION
This fixes the Bash file existence check so it handles paths with spaces on Windows.