### PR TITLE
Middle click tab close should not paste on linux - close #1816

### DIFF
--- a/src/lt/objs/tabs.cljs
+++ b/src/lt/objs/tabs.cljs
@@ -109,6 +109,10 @@
     (->name e)]
    (when (object/raise-reduce e :close-button+ false)
      (close-tab label))]
+  ;; Disable middle-click pasting in linux
+  :mouseup (fn [ev]
+             (when (or (= 1 (.-button ev)) (.-metaKey ev))
+               (dom/prevent ev)))
   :click (fn [ev]
            (if (or (= 1 (.-button ev)) (.-metaKey ev))
              (object/raise label :close)


### PR DESCRIPTION
Fix wasn't the most obvious but I confirmed it works on my ubuntu box. Merging later unless there's a concern