### PR TITLE
Fix scroll position jumping on save after stripping whitespace

### DIFF
--- a/src/lt/objs/editor/file.cljs
+++ b/src/lt/objs/editor/file.cljs
@@ -15,7 +15,9 @@
                       (let [{:keys [path]} (@editor :info)
                             final (object/raise-reduce editor :save+ (ed/->val editor))]
                         (when (not= final (ed/->val editor))
-                          (ed/set-val-and-keep-cursor editor final))
+                          (let [y-position (.-top (.getScrollInfo (ed/->cm-ed editor)))]
+                            (ed/set-val-and-keep-cursor editor final)
+                            (ed/scroll-to editor 0 y-position)))
                         (doc/save path final
                                   (fn []
                                     (object/merge! editor {:dirty false


### PR DESCRIPTION
#2097 restored cursor but forgot to restore scroll. 

You can recreate the bug by going to the middle of a big file [e.g. settings.cljs](https://github.com/LightTable/LightTable/blob/02e968f869dad546aeb27b7076e993c4a4531727/src/lt/objs/settings.cljs#L229) and putting the cursor in the middle of the screen. Add some whitespace to the end of the line and press save. While the cursor is preserved, the scroll position is lost and the cursor is dropped to the bottom of the screen.
Going out with tomorrow's release unless there are concerns