### PR TITLE
Use npm script for cross-platform grunt building

### DIFF
--- a/deploy/electron/package.json
+++ b/deploy/electron/package.json
@@ -1,6 +1,9 @@
 {
   "name": "download-electron",
   "version": "0.1.0",
+  "scripts": {
+    "download-electron": "grunt download-electron"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",

--- a/script/build.sh
+++ b/script/build.sh
@@ -22,7 +22,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"; cd ..
 # Ensure we have current version of electron
 pushd deploy/electron
   npm install
-  node_modules/.bin/grunt download-electron
+  npm run download-electron
 popd
 
 # Build the core cljs


### PR DESCRIPTION
Npm scripts will resolve the `grunt` executable automatically.

Cygwin does not pick up `node_modules/.bin/grunt` alone because `node_modules/.bin/grunt` does not exist when npm installs. When npm installs, it creates a `node_modules/.bin/grunt.cmd` which cannot be found by Cygwin.