### PR TITLE
Add note about installing additional Node.js package for Debian-based Linux distros

### DIFF
--- a/doc/developer-install.md
+++ b/doc/developer-install.md
@@ -41,6 +41,8 @@ To run electron on Linux you need to have libgconf-2.so.4 installed.
 
 Ref: [Linux (Arch) build depends on libgconf-2.so.4](https://github.com/LightTable/LightTable/issues/1926)
 
+Note that, on Debian-based distros, you may need to install an additional package as there is a pre-existing *node* package and the standard Node.js package on these distros installs a Node.js executable named `nodejs` instead of `node` as our build script expects. See issue [#1931](https://github.com/LightTable/LightTable/issues/1931) for some background.
+
 # Build
 
 To build LightTable from scratch on OSX, Windows Cygwin or Linux:


### PR DESCRIPTION
A contributor – @carocad – just ran into the issue covered by #1931 and mentioned it on [the Gitter room](https://gitter.im/LightTable/LightTable). A brief note in the 'developer install' doc seems like it might be helpful to others in the future.