### PR TITLE
 Update 'for committers' doc regarding building API docs and LT version #2202 

### DIFF
--- a/doc/for-committers.md
+++ b/doc/for-committers.md
@@ -67,7 +67,7 @@ This is our release checklist which can be dropped in to an issue:
 
 - [ ] Release 0.X.X
       - [ ] Version updates
-         - [ ] Update deploy/core/package.json, deploy/core/version.json and project.clj (including the Codox `:source-uri` value) to 0.X.X
+         - [ ] Update deploy/core/package.json, deploy/core/version.json and project.clj to 0.X.X
          - [ ] Make sure electron version is up to date in version.json
          - [ ] Make sure plugin versions in script/build.sh are latest versions
       - [ ] Add changelog for release to CHANGELOG.md
@@ -84,12 +84,8 @@ This is our release checklist which can be dropped in to an issue:
       - [ ] Optional blog post if a major release
       - [ ] After release, [build api documentation](#build-api-documentation)
 
-## Build api documentation
+## Build API documentation
 
-To build api documentation for current LT version and publish generated docs:
-
-1. In project.clj make sure that `[:codox :source-uri]` points to current LT version.
-   This step will be removed once [there is upstream support for version in :source-uri](https://github.com/weavejester/codox/issues/107)
-2. Run `script/build-api-docs.sh` on a clean git state. Make sure there are no pending git changes as this script will change git branches and push generated api docs to gh-pages.
+Run `script/build-api-docs.sh` on a clean git state to build API documentation for the current LT version and publish generated docs. Make sure there are no pending git changes as this script will change git branches and push generated API docs to gh-pages.
 
 Expect to see a ton of warnings e.g. `WARNING: Use of undeclared Var cljs.core/seq at line 197`. This will be noise we have to live with until we upgrade ClojureScript.

--- a/project.clj
+++ b/project.clj
@@ -28,15 +28,14 @@
                                   [org.clojure/clojurescript "1.7.145"
                                    :exclusions [org.apache.ant/ant]]]}}
   :plugins [[lein-cljsbuild "1.0.1"]
-            [lein-codox "0.9.0"]]
+            [lein-codox "0.9.5"]]
   :codox {:language :clojurescript
           :project {:name "LightTable"}
           :output-path "codox"
           :doc-paths [] ;; Disable including doc/
           :namespaces [lt.macros lt.object lt.objs.command lt.objs.editor
                        lt.objs.editor.pool lt.objs.files lt.objs.notifos]
-          ;; :source-uri version needs to be bumped per release until codox supports {version}
-          :source-uri "https://github.com/LightTable/LightTable/blob/0.8.1/{filepath}#L{line}"
+          :source-uri "https://github.com/LightTable/LightTable/blob/{version}/{filepath}#L{line}"
           ;; Be explicit that undocumented public fns should be documented
           :metadata {:doc "TODO: Add docstring"}}
   :source-paths ["src/"]


### PR DESCRIPTION
Implements #2202 

Updates codox to a version that makes use of {verison} in :codox :source-uri
Removes references about updating the version in :codox :source-uri for the committers doc 