### PR TITLE
Expand sidebar's rename functionality

### DIFF
--- a/deploy/core/css/structure.css
+++ b/deploy/core/css/structure.css
@@ -175,9 +175,6 @@ body { -webkit-user-select: none; }
 #side .workspace .folder, .folders { font-weight:bold; }
 #side .workspace > ul > li > div > ul.sub { margin:0; }
 #side .workspace ul.root > div > ul:empty:before { content:"Right click to add files or folders to the workspace or open a recent one to get started."; display:inline-block; text-align:center; width:100%; max-width:300px; margin-top:40px;  }
-#side .workspace input.rename { display:none; }
-#side .workspace li.renaming > input.rename { display:block; width:100%; }
-#side .workspace li.renaming > .tree-item > p { display:none; }
 #side .workspace.recents .wstree { display:none; }
 #side .workspace.recents .recent { display:block; width:100%; overflow:hidden; }
 #side .workspace .recent { display:none; }
@@ -257,6 +254,12 @@ body { -webkit-user-select: none; }
 #bottombar .horizontal-grip {position:absolute; top:0px; width:100%; height:10px; z-index:10000; cursor:row-resize; }
 #bottombar.closed { padding:0; }
 #bottombar.closed .horizontal-grip { display:none; }
+
+.rename-dialog { background-color:#505d6b; }
+
+#topbar {  z-index:100000; position:fixed; background:transparent; padding-top:0px; padding-bottom:0px; box-sizing:border-box; }
+#topbar .content { padding:10px 0px; padding-right:10px; box-sizing:border-box; height:100%; }
+#topbar.closed { display:none; }
 
 #statusbar-container { position:absolute; bottom:0; left:0; right:0; }
 

--- a/src/lt/objs/topbar.cljs
+++ b/src/lt/objs/topbar.cljs
@@ -1,0 +1,94 @@
+(ns lt.objs.topbar
+  "Provide topbar object and associated behaviors"
+  (:require [lt.object :as object]
+            [lt.objs.tabs :as tabs]
+            [lt.objs.animations :as anim]
+            [lt.objs.canvas :as canvas]
+            [lt.util.cljs :as cljs]
+            [lt.util.dom :as dom]
+            [lt.util.style :refer [->px]]
+            [crate.binding :refer [map-bound bound subatom]])
+  (:require-macros [lt.macros :refer [behavior defui]]))
+
+(def min-height 30)
+(def default-height 130)
+
+(defn active-content [active]
+  (when active
+    (object/->content active)))
+
+(declare topbar)
+
+(defn active? [item]
+  (= (:active @topbar) item))
+
+(defn ->active-class [{:keys [active]}]
+  (if active
+    "open"
+    "closed"))
+
+(defn add-item [bar item]
+  (object/update! bar [:items] assoc (:order @item) item)
+  (dom/append (dom/$ :.content (object/->content bar)) (object/->content item)))
+
+;;*********************************************************
+;; Object
+;;*********************************************************
+
+(object/object* ::topbar
+                :tags #{:topbar}
+                :behaviors #{::open! ::close! ::item-toggled}
+                :items (sorted-map-by >)
+                :height default-height
+                :max-height default-height
+                :open false
+                :init (fn [this]
+                        [:div#topbar {:class (bound this ->active-class)
+                                      :style {:left (bound (subatom tabs/multi :left) ->px)
+                                              :right (bound (subatom tabs/multi :right) ->px)
+                                              :top "50px"
+                                              :height (bound (subatom this :height) ->px)
+                                              }}
+                         [:div.content
+                          (bound (subatom this :active) active-content)]]))
+
+(def topbar (object/create ::topbar))
+
+(canvas/add! topbar)
+
+;;*********************************************************
+;; Behaviors
+;;*********************************************************
+
+(behavior ::open!
+          :triggers #{:open!}
+          :reaction (fn [this]
+                      (object/merge! this {:height (:max-height @this)
+                                           :open true})
+                      (dom/add-class (object/->content (:active @this)) :active)))
+
+(behavior ::close!
+          :triggers #{:close!}
+          :reaction (fn [this]
+                      (when (:active @this)
+                        (dom/remove-class (object/->content (:active @this)) :active))
+                      (object/merge! this {:height 0
+                                           :active false
+                                           :open false})))
+
+(behavior ::item-toggled
+          :triggers #{:toggle}
+          :reaction (fn [this item {:keys [force? transient? soft?]}]
+                      (if (and (not force?)
+                               (= (:active @this) item)
+                               (:open @this))
+                        (object/raise this :close!)
+                        (when (not= (:active @this) item)
+                          (when (:active @this)
+                            (dom/remove-class (object/->content (:active @this)) :active))
+                          (object/merge! this {:active item})
+                          (object/raise this :open!)
+                          (when-not soft?
+                            (object/raise item :show)
+                            )
+                          ))))


### PR DESCRIPTION
The Pull Request is for issue #2218. Rather than add a new, somewhat redundant, move function to the context menu in the sidebar, it was decided to expand the rename functionality.

It should be possible to now edit the file/folder name as well as the location of the file/folder within the filesystem. Below is an example of the UI at the start of the PR:

![pr screenshot from 2016-07-30 00-37-03 cropped](https://cloud.githubusercontent.com/assets/2945386/17268129/3377dd00-55ee-11e6-8f25-7cd651782579.png)

This is currently a Work in Progress - looking for feedback! :smile: 
