### PR TITLE
Add initial LightTable Style Guide document - close #2236

### DIFF
--- a/doc/for-committers.md
+++ b/doc/for-committers.md
@@ -39,10 +39,7 @@ Allows us to build cross platfrom desktop apps. See [Electron guide](electron-gu
 
 ### Code Conventions
 
-* Catch blocks should catch on `:default` unless there is a specific exception to be caught.
-* Catch blocks should log errors with `lt.objs.console/error`. Namespaces that the console
-  ns depend on cannot refer to the clojure var but can refer to the js fn e.g.
-  `(js/lt.objs.console.error err)`.
+* See the LightTable Style Guide.
 
 ### Code Reading
 

--- a/doc/style-guide.md
+++ b/doc/style-guide.md
@@ -1,0 +1,17 @@
+# LightTable Style Guide
+
+Follow the [Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide) unless directed otherwise below. The guide is comprehensive, well organized, and common.
+
+In order to streamline pull requests, prior to opening one, consider running your code through a formatting tool such as [cljfmt](https://github.com/weavejester/cljfmt) or [kibit](https://github.com/jonase/kibit). They are handy for catching any deviations from standard Clojure/script style guidelines.
+
+## Documentation and Comments
+
+1. Unless obvious to someone new to the project, yet familiar with Clojure/script, a meaningful docstring should be associated with every class, function, behavior, and object.
+
+## Behaviors
+
+1. Add brief docstrings via `:desc` key.
+
+## Footnotes
+
+1. This document was inspired by the excellent [Metabase Clojure Style Guide](https://github.com/metabase/metabase/wiki/Metabase-Clojure-Style-Guide).

--- a/doc/style-guide.md
+++ b/doc/style-guide.md
@@ -8,6 +8,13 @@ In order to streamline pull requests, prior to opening one, consider running you
 
 1. Unless obvious to someone new to the project, yet familiar with Clojure/script, a meaningful docstring should be associated with every class, function, behavior, and object.
 
+## Errors
+
+1. Catch blocks should catch on `:default` unless there is a specific exception to be caught.
+1. Catch blocks should log errors with `lt.objs.console/error`. Namespaces that the console
+  ns depend on cannot refer to the clojure var but can refer to the js fn e.g.
+  `(js/lt.objs.console.error err)`.
+
 ## Behaviors
 
 1. Add brief docstrings via `:desc` key.


### PR DESCRIPTION
This is pull request adds the LightTable Style Guide to our docs folder per issue #2236. At the moment, the document is small and primarily points to the [Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide) as it is comprehensive and popular.

It should be expected that our style guide will expand over time to cover various areas unique to LightTable, such as Behaviors, Objects, and Tags.

Please feel free to add to the guide!