### PR TITLE
Add documentation to editor and files namespaces - closes #2060

### DIFF
--- a/doc/for-committers.md
+++ b/doc/for-committers.md
@@ -93,3 +93,5 @@ This is our release checklist which can be dropped in to an issue:
 Run `script/build-api-docs.sh` on a clean git state to build API documentation for the current LT version and publish generated docs. Make sure there are no pending git changes as this script will change git branches and push generated API docs to gh-pages.
 
 Expect to see a ton of warnings e.g. `WARNING: Use of undeclared Var cljs.core/seq at line 197`. This will be noise we have to live with until we upgrade ClojureScript.
+
+To build documentation locally for debugging of documentation generation, run `lein with-profile doc codox`. This will create a `codox` directory within the LightTable directory. Do not include in pull requests or commits. Note, the generated documenation will not have styling, and the view source links may be incorrect.

--- a/doc/style-guide.md
+++ b/doc/style-guide.md
@@ -4,9 +4,11 @@ Follow the [Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide)
 
 In order to streamline pull requests, prior to opening one, consider running your code through a formatting tool such as [cljfmt](https://github.com/weavejester/cljfmt) or [kibit](https://github.com/jonase/kibit). They are handy for catching any deviations from standard Clojure/script style guidelines.
 
-## Documentation and Comments
+## Documentation, Comments, and Examples
 
 1. Unless obvious to someone new to the project, yet familiar with Clojure/script, a meaningful docstring should be associated with every class, function, behavior, and object.
+2. When adding examples use the [ClojureDocs Example Style Guide](https://clojuredocs.org/examples-styleguide) as a reference for creating quality examples.
+3. Good articles for quality documentation can be found [here](https://jacobian.org/writing/great-documentation/) and [here](https://bradfults.com/the-best-api-documentation-b9e46400379a).
 
 ## Errors
 

--- a/project.clj
+++ b/project.clj
@@ -37,6 +37,7 @@
                        lt.objs.editor.pool lt.objs.files lt.objs.notifos]
           :source-uri "https://github.com/LightTable/LightTable/blob/{version}/{filepath}#L{line}"
           ;; Be explicit that undocumented public fns should be documented
-          :metadata {:doc "TODO: Add docstring"}}
+          :metadata {:doc "TODO: Add docstring"
+                     :doc/format :markdown}}
   :source-paths ["src/"]
   )

--- a/src/lt/objs/editor.cljs
+++ b/src/lt/objs/editor.cljs
@@ -1,7 +1,21 @@
 (ns lt.objs.editor
   "Provide fns and behaviors for interfacing with a CodeMirror editor
-  object. Also manage defining and loading CodeMirror. For more about CodeMirror
-  objects see http://codemirror.org/doc/manual.html#CodeMirror"
+  object. Also manage defining and loading [CodeMirror](http://codemirror.net/doc/manual.html).
+
+  Editor objects are frequently used as arguements for functions, but often only the internal
+  CodeMirror object is actually used. Where the following documentation referers to the editor,
+  it is informally referring to the editor's CodeMirror object.
+
+  Commonly encountered arguement names:
+
+  * `e` - Editor
+  * `v` - Value
+  * `m` - Map
+  * `cm` - CodeMirror object
+  * `opts` - Options
+  * `ev` - Event Handler
+  * `pos` - Position: depending on the context, either a Javascript object
+            (e.g., `{\"line\": 0, \"ch\": 0}`) or cljs map (e.g., `{:line 0 :ch 0}`)."
   (:refer-clojure :exclude [val replace range])
   (:require [crate.core :as crate]
             [lt.objs.context :as ctx-obj]
@@ -18,46 +32,52 @@
   (:require-macros [lt.macros :refer [behavior]]))
 
 (defn ->cm-ed
-  "Return editor's CodeMirror object"
+  "Return editor `e`'s CodeMirror object."
   [e]
   (if (satisfies? IDeref e)
     (:ed @e)
     e))
 
 (defn ->elem
-  "Return DOM element of editor's CodeMirror object"
+  "Return DOM element of editor `e`'s CodeMirror object"
   [e]
   (.-parentElement (.getScrollerElement (->cm-ed e))))
 
 (defn set-val
-  "Set content value of editor's CodeMirror object. Cursor position is lost"
+  "Set content value `v` of editor `e`'s CodeMirror object. Cursor position is lost. Returns `e`."
   [e v]
   (. (->cm-ed e) (setValue (or v "")))
   e)
 
 (defn set-val-and-keep-cursor
-  "Same as set-val but current cursor position is kept"
+  "Same as [[set-val]] but current cursor position is kept."
   [e v]
   (let [cursor (.getCursor (->cm-ed e))]
     (set-val e v)
     (.setCursor (->cm-ed e) cursor)))
 
 (defn set-options
-  "Given a map of options, set each pair as an option on editor's
-  CodeMirror object"
+  "Given a map of options, set each pair as an option on editor `e`'s
+  CodeMirror object. Returns `e`."
   [e m]
   (doseq [[k v] m]
     (.setOption (->cm-ed e) (name k) v))
   e)
 
-(defn clear-history [e]
+(defn clear-history
+  "Clear the history of editor `e`. Returns `e`."
+  [e]
   (.clearHistory (->cm-ed e))
   e)
 
-(defn get-history [e]
+(defn get-history
+  "Returns the history of editor `e`."
+  [e]
   (.getHistory (->cm-ed e)))
 
-(defn set-history [e v]
+(defn set-history
+  "Set the history of editor `e` with provided value `v`."
+  [e v]
   (.setHistory (->cm-ed e) v)
   e)
 
@@ -79,7 +99,9 @@
 ;; Creating
 ;;*********************************************************
 
-(defn- headless [opts]
+(defn- headless
+  "Create a headless CodeMirror object using `opts`."
+  [opts]
   (-> (js/CodeMirror. (fn []))
       (set-options opts)))
 
@@ -101,12 +123,12 @@
     e))
 
 (defn on
-  "Register event handler on editor's CodeMirror object"
+  "Register event handler `ev`, which fires `func`, on editor `ed`'s CodeMirror object."
   [ed ev func]
   (.on (->cm-ed ed) (name ev) func))
 
 (defn off
-  "Remove event handler on editor's CodeMirror object"
+  "Remove event handler `ev`, which fires `func`, on editor `ed`'s CodeMirror object."
   [ed ev func]
   (.off (->cm-ed ed) (name ev) func))
 
@@ -129,101 +151,188 @@
 ;;*********************************************************
 
 (defn ->val
-  "Return editor's CodeMirror object buffer contents"
+  "Return editor `e`'s buffer content."
   [e]
   (. (->cm-ed e) (getValue)))
 
-(defn ->token [e pos]
+(defn ->token
+  "Returns token located as `pos` within editor `e`.
+
+  See [getTokenAt](http://codemirror.net/doc/manual.html#getTokenAt)."
+  [e pos]
   (js->clj (.getTokenAt (->cm-ed e) (clj->js pos)) :keywordize-keys true))
 
 (defn- ->token-js [e pos]
   (.getTokenAt (->cm-ed e) (clj->js pos)))
 
-(defn ->token-type [e pos]
+(defn ->token-type
+  "Return the type of token located at position `pos` for editor `e`.
+
+  See [getTokenTypeAt](http://codemirror.net/doc/manual.html#getTokenTypeAt)."
+  [e pos]
   (.getTokenTypeAt (->cm-ed e) (clj->js pos)))
 
-(defn- ->coords [e]
+(defn- ->coords
+  "Returns cursor's coordinates of the form `{:left :top: bottom}` for editor `e`.
+
+  See [cursorCoords](http://codemirror.net/doc/manual.html#cursorCoords)."
+  [e]
   (js->clj (.cursorCoords (->cm-ed e)) :keywordize-keys true :force-obj true))
 
-(defn- +class [e klass]
+(defn- +class
+  "Add class `klass` to editor `e`. Returns `e`."
+  [e klass]
   (add-class (->elem e) (name klass))
   e)
 
-(defn- -class [e klass]
+(defn- -class
+  "Remove class `klass` from editor `e`. Returns `e`."
+  [e klass]
   (remove-class (->elem e) (name klass))
   e)
 
 (defn cursor
-  "Return cursor of editor's CodeMirror object as js object.
-   Example: #js {:line 144, :ch 9}"
+  "Return cursor position of editor `e`'s as js object. Returns JSON not edn...
+  use [[->cursor]] for edn.
+
+  Example:
+  ```
+  (cursor e)
+  ;;=> {\"line\": 144, \"ch\": 9}
+  ```"
   ([e] (cursor e nil))
   ([e side] (.getCursor (->cm-ed e) side)))
 
 (defn ->cursor
-  "Same as cursor but returned as cljs map"
+  "Same as [[cursor]] but returned as edn."
   [e & [side]]
   (let [pos (cursor e side)]
     {:line (.-line pos)
      :ch (.-ch pos)}))
 
-(defn pos->index [e pos]
+(defn pos->index
+  "Returns integer based on position `pos` from editor's CodeMirror Object.
+  Position consists of line and character indexes as JSON, such as:
+
+  ```
+  {\"line\": 144, \"ch\": 9}
+  ```
+
+  Reverse of [posFromIndex](http://codemirror.net/doc/manual.html#posFromIndex)."
+  [e pos]
   (.indexFromPos (->cm-ed e) (clj->js pos)))
 
-(defn mark [e from to opts]
+(defn mark
+  "Marks text in editor `e` within range of `from` and `to`.
+
+  See [markText](http://codemirror.net/doc/manual.html#markText)."
+  [e from to opts]
   (.markText (->cm-ed e) (clj->js from) (clj->js to) (clj->js opts)))
 
-(defn find-marks [e pos]
+(defn find-marks
+  "Returns marks found at `pos` in .
+
+  See [findMarksAt](http://codemirror.net/doc/manual.html#findMarksAt)."
+  [e pos]
   (.findMarksAt (->cm-ed e) (clj->js pos)))
 
-(defn bookmark [e from widg]
+(defn bookmark
+  "Insert bookmark at position `from` for widget `widg`.
+
+  See [setBookmark](http://codemirror.net/doc/manual.html#setBookmark)."
+  [e from widg]
   (.setBookmark (->cm-ed e) (clj->js from) (clj->js widg)))
 
 (defn option
-  "Return value for option name on editor's CodeMirror object"
+  "Return value for option name `o` on editor `e`.
+
+  See [getOption](http://codemirror.net/doc/manual.html#getOption)."
   [e o]
   (.getOption (->cm-ed e) (name o)))
 
-(defn set-mode [e m]
+(defn set-mode
+  "Set mode option for editor `e`.
+
+  See [getOption](http://codemirror.net/doc/manual.html#getOption)."
+  [e m]
   (.setOption (->cm-ed e) "mode" m)
   e)
 
-(defn ->mode [e]
+(defn ->mode
+  "Return outer mode object for editor `e`.
+
+  See [getMode](http://codemirror.net/doc/manual.html#getMode)."
+  [e]
   (.getMode (->cm-ed e)))
 
-(defn focus [e]
+(defn focus
+  "Return focus of editor.
+
+  See [focus](http://codemirror.net/doc/manual.html#focus)."
+  [e]
   (.focus (->cm-ed e))
   e)
 
-(defn input-field [e]
+(defn input-field
+  "Return input field element of editor.
+
+  See [getInputField](http://codemirror.net/doc/manual.html#getInputField)."
+  [e]
   (.getInputField e))
 
-(defn blur [e]
+(defn blur
+  "Blurs input field `e`. Returns `e`."
+  [e]
   (.blur (input-field e))
   e)
 
-(defn refresh [e]
+(defn refresh
+  "Refreshes editor. Returns `e`.
+
+  See [refresh](http://codemirror.net/doc/manual.html#refresh)."
+  [e]
   (.refresh (->cm-ed e))
   e)
 
-(defn on-move [e func]
+(defn on-move
+  "Add function `func` to trigger when `onCursorActivity` event fires.
+  `func` should take two arguments, `ed` and `delta`. Returns `e`.
+
+  See [cursorActivity](http://codemirror.net/doc/manual.html#event_cursorActivity)"
+  [e func]
   (.on e "onCursorActivity"
        (fn [ed delta]
          (func ed delta)))
   e)
 
-(defn on-change [e func]
+(defn on-change
+  "Add function `func` to trigger when `onChange` event fires.
+  `func` should take two arguments, `ed` and `delta`. Returns `e`.
+
+  See [change](http://codemirror.net/doc/manual.html#event_change)"
+  [e func]
   (.on e "onChange"
        (fn [ed delta]
          (func ed delta)))
   e)
 
-(defn on-update [e func]
+(defn on-update
+  "Add function `func` to trigger when `onUpdate` event fires.
+  `func` should take two arguments, `ed` and `delta`. Returns `e`.
+
+  See [update](http://codemirror.net/doc/manual.html#event_update)"
+  [e func]
   (.on e "onUpdate"
        (fn [ed delta]
          (func ed delta)))
   e)
 
-(defn on-scroll [e func]
+(defn on-scroll
+  "Add function `func` to trigger when `onScroll` event fires.
+  `func` should take two arguments, `ed`. Returns `e`.
+
+  See [scroll](http://codemirror.net/doc/manual.html#event_scroll)"
+  [e func]
   (.on e "onScroll"
        (fn [ed]
          (func ed)
@@ -231,131 +340,252 @@
   e)
 
 (defn replace
+  "Replace text starting at position `from` for editor with text `v`. If provided, replace will stop at position `to`.
+
+  See [replaceRange](http://codemirror.net/doc/manual.html#replaceRange)."
   ([e from v]
    (.replaceRange (->cm-ed e) v (clj->js from)))
   ([e from to v]
    (.replaceRange (->cm-ed e) v (clj->js from) (clj->js to))))
 
-(defn range [e from to]
+(defn range
+  "Returns text between positions `from` and `to`.
+
+  See [getRange](http://codemirror.net/doc/manual.html#getRange)."
+  [e from to]
   (.getRange (->cm-ed e) (clj->js from) (clj->js to)))
 
-(defn line-count [e]
+(defn line-count
+  "Returns the number of lines in the editor.
+
+  See [lineCount](http://codemirror.net/doc/manual.html#lineCount)."
+  [e]
   (.lineCount (->cm-ed e)))
 
-(defn insert-at-cursor [ed s]
+(defn insert-at-cursor
+  "Insert into editor `ed` text `s` at cursor's position. Returns `ed`."
+  [ed s]
   (replace (->cm-ed ed) (->cursor ed) s)
   ed)
 
-(defn move-cursor [ed pos]
+(defn move-cursor
+  "Moves editor `ed`'s cursor to position `pos`. If `pos` is nil then default position of line 0, ch 0 is used.
+
+  See [setCursor](http://codemirror.net/doc/manual.html#setCursor)."
+  [ed pos]
   (.setCursor (->cm-ed ed) (clj->js (or pos {:line 0 :ch 0}))))
 
-(defn scroll-to [ed x y]
+(defn scroll-to
+  "Scroll editor to pixel position `x`,`y`.
+
+  See [scrollTo](http://codemirror.net/doc/manual.html#scrollTo)."
+  [ed x y]
   (.scrollTo (->cm-ed ed) x y))
 
-(defn center-cursor [ed]
+(defn center-cursor
+  "Scrolls editor `ed` to the cursor and places it in the center of screen."
+  [ed]
   (let [l (:line (->cursor ed))
         y (.-top (.charCoords (->cm-ed ed) (clj->js {:line l :ch 0}) "local"))
         half-h (/ (.-offsetHeight (.getScrollerElement (->cm-ed ed))) 2)]
     (scroll-to ed nil (- y half-h -55))))
 
-(defn selection? [e]
+(defn selection?
+  "True if text is selected in editor.
+
+  See [somethingSelected](http://codemirror.net/doc/manual.html#somethingSelected)."
+  [e]
   (.somethingSelected (->cm-ed e)))
 
-(defn selection-bounds [e]
+(defn selection-bounds
+  "When text is selected, returns position `{:from x :to y}` where `x` and `y` are the cursor's start and end values."
+  [e]
   (when (selection? e)
-    {:from (->cursor e"start")
+    {:from (->cursor e "start")
      :to (->cursor e "end")}))
 
-(defn selection [e]
+(defn selection
+  "Returns currently selected text in editor.
+
+  See [getSelection](http://codemirror.net/doc/manual.html#getSelection)."
+  [e]
   (.getSelection (->cm-ed e)))
 
-(defn set-selection [e start end]
+(defn set-selection
+  "Sets editor's selection to `start` and `end` positions.
+
+  See [setSelection](http://codemirror.net/doc/manual.html#setSelection)."
+  [e start end]
   (.setSelection (->cm-ed e) (clj->js start) (clj->js end)))
 
-(defn set-extending [e ext?]
+(defn set-extending
+  "Sets editor's 'extending' flag to `ext?`.
+
+  See [setExtending](http://codemirror.net/doc/manual.html#setExtending)."
+  [e ext?]
   (.setExtending (->cm-ed e) ext?))
 
-(defn replace-selection [e neue & [after]]
+(defn replace-selection
+  "Replace selection with `neue` for editor `e`.
+
+  See [replaceSelection](http://codemirror.net/doc/manual.html#replaceSelection)."
+  [e neue & [after]]
   (.replaceSelection (->cm-ed e) neue (name (or after :end)) "+input"))
 
-(defn undo [e]
+(defn undo
+  "Undo one edit for editor `e`, if any exist.
+
+  See [undo](http://codemirror.net/doc/manual.html#undo)."
+  [e]
   (.undo (->cm-ed e)))
 
-(defn redo [e]
+(defn redo
+  "Redo one edit for editor `e`, if any exist.
+
+  See [redo](http://codemirror.net/doc/manual.html#redo)."
+  [e]
   (.redo (->cm-ed e)))
 
-(defn copy [e]
+(defn copy
+  "Copies currently selected text from editor."
+  [e]
   (platform/copy (selection e)))
 
-(defn cut [e]
+(defn cut
+  "Cut currently selected text from editor."
+  [e]
   (copy e)
   (replace-selection e ""))
 
-(defn paste [e]
+(defn paste
+  "Paste into editor's current cursor position "
+  [e]
   (replace-selection e (platform/paste)))
 
-(defn char-coords [e pos]
+(defn char-coords
+  "Returns position and dimension, based off of `pos` for editor `e`, in map consisting of `{:left :right :top :bottom}`.
+
+  See [charChords](http://codemirror.net/doc/manual.html#charCoords)."
+  [e pos]
   (js->clj (.charCoords (->cm-ed e) (clj->js pos)) :keywordize-keys true :force-obj true))
 
-(defn operation [e func]
+(defn operation
+  "Returns `e` rather than the return value of your function `func`.
+
+  See [operation](http://codemirror.net/doc/manual.html#operation)."
+  [e func]
   (.operation (->cm-ed e) func)
   e)
 
-(defn on-click [e func]
+(defn on-click
+  "Add function `func` to trigger when `:mousedown` fires.
+
+  Returns editor `e`."
+  [e func]
   (let [elem (->elem e)]
     (ev/capture elem :mousedown func)
     e))
 
-(defn extension [name func]
+(defn extension
+  "Add function `func` named `name` to CodeMirror API.
+
+  See [defineExtension](http://codemirror.net/doc/manual.html#defineExtension)."
+  [name func]
   (.defineExtension js/CodeMirror name func))
 
-(defn line-widget [e line elem & [opts]]
+(defn line-widget
+  "Add line widget `elem` (an element), along with any options, at `line` to editor `e`.
+
+  See [addLineWidget](http://codemirror.net/doc/manual.html#addLineWidget)."
+  [e line elem & [opts]]
   (.addLineWidget (->cm-ed e) line elem (clj->js opts)))
 
-(defn remove-line-widget [e widg]
+(defn remove-line-widget
+  "Remove widget `widg` from editor `e`. Opposite of `line-widget`."
+  [e widg]
   (.removeLineWidget (->cm-ed e) widg))
 
-(defn line [e l]
+(defn line
+  "Returns the content of line `l` from editor `e`.
+
+  See [getLine](http://codemirror.net/doc/manual.html#getLine)."
+  [e l]
   (.getLine (->cm-ed e) l))
 
-(defn first-line [e]
+(defn first-line
+  "Returns the first line of editor `e`.
+
+  See [firstLine](http://codemirror.net/doc/manual.html#firstLine)."
+  [e]
   (.firstLine (->cm-ed e)))
 
-(defn last-line [e]
+(defn last-line
+  "Returns the last line of editor `e`.
+
+  See [lastLine](http://codemirror.net/doc/manual.html#lastLine)."
+  [e]
   (.lastLine (->cm-ed e)))
 
-(defn line-handle [e l]
+(defn line-handle
+  "Returns `LineHandle` object from editor `e` for line `l`.
+
+  See [getLineHandle](http://codemirror.net/doc/manual.html#getLineHandle)."
+  [e l]
   (.getLineHandle (->cm-ed e) l))
 
-(defn lh->line [e lh]
+(defn lh->line
+  "Given LineHandle object `lh`, returns integer for corresponding line from editor `e`.
+
+  See [getLineNumber](http://codemirror.net/doc/manual.html#getLineNumber)."
+  [e lh]
   (.getLineNumber (->cm-ed e) lh))
 
-(defn line-length [e l]
+(defn line-length
+  "Returns the length of line `l` from editor `e`."
+  [e l]
   (count (line e l)))
 
-(defn select-all [e]
+(defn select-all
+  "Select all lines from editor `e`."
+  [e]
   (set-selection e
                  {:line (first-line e) :ch 0}
                  {:line (last-line e)}))
 
-(defn set-line [e l text]
+(defn set-line
+  "Replace content at line `l` with `text` for editor `e`."
+  [e l text]
   (let [length (line-length e l)]
     (replace e
              {:line l :ch 0}
              {:line l :ch length}
              text)))
 
-(defn +line-class [e lh plane class]
+(defn +line-class
+  "Add CSS class name `class` to LineHandle `lh` at element `plane` for editor `e`.
+
+  See [addLineClass](http://codemirror.net/doc/manual.html#addLineClass)."
+  [e lh plane class]
   (.addLineClass (->cm-ed e) lh (name plane) (name class)))
 
-(defn -line-class [e lh plane class]
+(defn -line-class
+  "Remove CSS class name `class` from LineHandle `lh` at element `plane` for editor `e`.
+  Opposite of `+line-class`.
+
+  See [removeLineClass](http://codemirror.net/doc/manual.html#removeLineClass)."
+  [e lh plane class]
   (.removeLineClass (->cm-ed e) lh (name plane) (name class)))
 
-(defn show-hints [e hint-fn options]
+(defn show-hints
+  "Display hint `hint-fn` for editor `e` with any provided options.
+
+  See [show-hint.js](http://codemirror.net/addon/hint/show-hint.js)."
+  [e hint-fn options]
   (js/CodeMirror.showHint (->cm-ed e) hint-fn (clj->js options))
   e)
 
 (defn inner-mode
+  "Sets the innerMode of editor `e`'s CodeMirror object with `state` if provided. Returns the mode."
   ([e] (inner-mode e nil))
   ([e state]
    (let [state (or state (->> (cursor e) (->token-js e) (.-state)))]
@@ -363,22 +593,37 @@
          (.-mode)))))
 
 (defn adjust-loc
+  "Adjust position `loc` with integer offset `dir` and the key `axis`. Axis should either be `:line` or `:ch`.
+  If `axis` is not specified, defaults to `:ch`."
   ([loc dir]
    (adjust-loc loc dir :ch))
   ([loc dir axis]
    (when loc
      (update-in loc [axis] + dir))))
 
-(defn get-char [ed dir]
+(defn get-char
+  "Returns the characters found from integer offest `dir` to the current cursor position.
+
+  See range."
+  [ed dir]
   (let [loc (->cursor ed)]
     (if (> dir 0)
       (range ed loc (adjust-loc loc dir))
       (range ed (adjust-loc loc dir) loc))))
 
-(defn indent-line [e l dir]
+(defn indent-line
+  "Indents the line `l` based on the `dir` specified for editor `e`.
+
+  See [indent-line](http://codemirror.net/doc/manual.html#indentLine)."
+  [e l dir]
   (.indentLine (->cm-ed e) l dir))
 
-(defn indent-lines [e from to dir]
+(defn indent-lines
+  "Indents lines within the range resulting from `from` and `to` based on the `dir` specified
+  for editor `e`.
+
+  See [indent-line](http://codemirror.net/doc/manual.html#indentLine)."
+  [e from to dir]
   (let [ed (->cm-ed e)
         diff (- (:line to) (:line from))]
     (if (zero? diff)
@@ -386,16 +631,32 @@
       (dotimes [x (inc diff)]
         (.indentLine ed (+ (:line from) x))))))
 
-(defn indent-selection [e dir]
+(defn indent-selection
+  "Intent current selection in editor `e` by integer offset `dir`."
+  [e dir]
   (.indentSelection (->cm-ed e) dir))
 
-(defn line-comment [e from to opts]
+(defn line-comment
+  "Changes lines within range of `from` and `to` into line comments for editor `e`.
+
+  See [lineComment](http://codemirror.net/doc/manual.html#lineComment)."
+  [e from to opts]
   (.lineComment (->cm-ed e) (clj->js from) (clj->js to) (clj->js opts)))
 
-(defn uncomment [e from to opts]
+(defn uncomment
+  "Attempts to uncomment lines within range of `from` and `to` for editor `e`.
+
+  Returns `true` if comment range was successfully removed.
+
+  See [uncomment](http://codemirror.net/doc/manual.html#uncomment)."
+  [e from to opts]
   (.uncomment (->cm-ed e) (clj->js from) (clj->js to) (clj->js opts)))
 
-(defn block-comment [e from to opts]
+(defn block-comment
+  "Wrap lines within range of `from` and `to` for editor `e`.
+
+  See [blockComment](http://codemirror.net/doc/manual.html#blockComment)."
+  [e from to opts]
   (.blockComment (->cm-ed e) (clj->js from) (clj->js to) (clj->js opts)))
 
 (defn toggle-comment
@@ -406,20 +667,41 @@
       (block-comment e from to opts)
       (line-comment e from (->cursor e "end") opts))))
 
-(defn ->generation [e]
+(defn ->generation
+  "Returns an integer that can be used to test if edits have occurred.
+
+  See [changeGeneration](http://codemirror.net/doc/manual.html#changeGeneration)."
+  [e]
   (.changeGeneration (->cm-ed e)))
 
-(defn dirty? [e gen]
+(defn dirty?
+  "Returns true if document is not clean for generation `gen`. The document is not clean if it has been modified since it was in a clean state.
+
+  See [isClean](http://codemirror.net/doc/manual.html#isClean)."
+  [e gen]
   (not (.isClean (->cm-ed e) gen)))
 
-(defn get-doc [e]
+(defn get-doc
+  "Returns currently active document for the editor.
+
+  See [getDoc](http://codemirror.net/doc/manual.html#getDoc)."
+  [e]
   (.getDoc (->cm-ed e)))
 
-(defn set-doc! [e doc]
+(defn set-doc!
+  "Adds document `doc` to editor `e`. If there is already a document associated with the editor then it is replaced. Returns old document.
+
+  See [swapDoc](http://codemirror.net/doc/manual.html#swapDoc)."
+  [e doc]
   (object/merge! e {:doc doc})
   (.swapDoc (->cm-ed e) (:doc @doc)))
 
 (defn fold-code
+  "Attempts to fold code starting at position `loc`. If position is not provided then folding will be attempted at the cursor position.
+
+  If the code is already folded then an attempt to unfold will occur.
+
+  See [foldcode.js](http://codemirror.net/addon/fold/foldcode.js) addon."
   ([e]
    (fold-code e (->cursor e)))
   ([e loc]
@@ -442,13 +724,17 @@
                      (if-let [gutter (dom/$ (str "div." k) gutter-div)]
                        (dom/set-css gutter {"width" (str v "px")})))))))
 
-(defn add-gutter [e class-name width]
+(defn add-gutter
+  "Add gutter with `class-name` of specified `width` to editor `e`."
+  [e class-name width]
   (let [gutter-classes (set (conj (js->clj (option e "gutters")) class-name))
         current-widths (gutter-widths e)
         new-gutter-widths (assoc current-widths class-name width)]
     (update-gutters e gutter-classes new-gutter-widths)))
 
-(defn remove-gutter [e class-name]
+(defn remove-gutter
+  "Remove gutter with `class-name` from editor `e`."
+  [e class-name]
   (let [gutter-classes (remove #{class-name} (js->clj (option e "gutters")))
         current-widths (gutter-widths e)]
     (update-gutters e gutter-classes current-widths)))

--- a/src/lt/objs/files.cljs
+++ b/src/lt/objs/files.cljs
@@ -1,6 +1,6 @@
 (ns lt.objs.files
   "Provide fns for doing file related operations. A number of fns
-  use the node fs library - https://nodejs.org/api/fs.html"
+  use the node [fs library](https://nodejs.org/api/fs.html) or [path library](https://nodejs.org/api/path.html)."
   (:refer-clojure :exclude [open exists?])
   (:require [lt.object :as object]
             [lt.util.load :as load]
@@ -29,7 +29,9 @@
 (defn- join [& segs]
   (apply (.-join fpath) (filter string? (map str segs))))
 
-(def ignore-pattern #"(^\..*)|\.class$|target/|svn|cvs|\.git|\.pyc|~|\.swp|\.jar|.DS_Store")
+(def ignore-pattern
+  "Regex pattern consisting of files, folders, etc... to ignore."
+  #"(^\..*)|\.class$|target/|svn|cvs|\.git|\.pyc|~|\.swp|\.jar|.DS_Store")
 
 (declare files-obj)
 
@@ -63,10 +65,10 @@
                                                         :exts {}
                                                         :types {})))
 
-(def line-ending "Current platform-specific line" (.-EOL os))
-(def separator "Current platform-specific file separator" (.-sep fpath))
+(def line-ending "Current platform-specific line ending." (.-EOL os))
+(def separator "Current platform-specific file separator." (.-sep fpath))
 (def ^:private available-drives #{})
-(def cwd "Directory process is started in" (js/process.cwd))
+(def cwd "Directory process is started in." (js/process.cwd))
 
 (when (= separator "\\")
   (.exec (js/require "child_process") "wmic logicaldisk get name"
@@ -77,15 +79,43 @@
            )))
 
 (defn basename
+  "Extracts the basename of the `path`, typically the end of the path.
+
+  If `ext` is provided then the result returned will not contain the extension.
+
+  Example:
+  ```
+  (basename \"/foo/bar/baz.txt\")
+  ;;=> \"baz.txt\"
+
+  (basename \"/foo/bar/baz.txt\" \".txt\")
+  ;;=> \"baz\"
+  ```"
   ([path] (.basename fpath path))
   ([path ext] (.basename fpath path ext)))
 
-(defn get-roots []
+(defn get-roots
+  "Example:
+  ```
+  (get-roots) ;;=> #{\"/\"}
+  ```"
+  []
   (if (= separator "\\")
     available-drives
     #{"/"}))
 
-(defn- get-file-parts [path]
+(defn- get-file-parts
+  "Returns the exploded basename of `path` with each element after the first split on `.`.
+
+  Example:
+  ```
+  (get-file-parts \"./foo/bar/\")
+  ;;=> [\"bar\"]
+
+  (get-file-parts \"./foo/bar/bas.txt.md.clj\")
+  ;;=> [\"bas.txt.md.clj\" \"txt.md.clj\" \"md.clj\" \"clj\"]
+  ```"
+  [path]
   (let [filename (basename path)
         file-parts (string/split filename #"\.")]
     (loop [parts file-parts
@@ -94,31 +124,112 @@
         acc
         (recur (rest parts) (conj acc (string/join "." parts)))))))
 
-(defn ext [path]
+(defn ext
+  "Returns the last extention of `path`, without the leading `.`, determined by the final `.` of the path.
+
+  Example:
+  ```
+  (ext \"foo.txt\")         ;;=> \"txt\"
+
+  (ext \"foo/bar.txt.tar\") ;;=> \"tar\"
+
+  (ext \"foo.\")            ;;=> \"\"
+
+  (ext \"foo\")             ;;=> \"\"
+  ```"
+  [path]
   (subs (.extname fpath path) 1))
 
-(defn without-ext [path]
+(defn without-ext
+  "Returns the `path`, but without the last extension, deteremined by the final `.` of the path.
+
+  Example:
+  ```
+  (without-ext \"foo.txt\")         ;;=> \"foo\"
+
+  (without-ext \"foo/bar.txt.tar\") ;;=> \"foo/bar.txt\"
+
+  (without-ext \"foo.\")            ;;=> \"foo\"
+
+  (without-ext \"foo\")             ;;=> \"foo\"
+  ```"
+  [path]
   (let [i (.lastIndexOf path ".")]
     (if (> i 0)
       (subs path 0 i)
       path)))
 
-(defn- ext->type [ext]
+(defn- ext->type
+  "Extracts type information based on `ext`, which must be a keyword.
+
+  Example:
+  ```
+  (ext->type :txt)
+  ;;=> {:exts [:txt], :mime \"plaintext\", :tags [:editor.plaintext], :name \"Plain Text\"}
+
+  (ext->type :cljs)
+  ;;=> {:exts [:cljs], :mime \"text/x-clojurescript\", :tags [:editor.cljs :editor.clojurescript], :name \"ClojureScript\"}
+
+  (ext->type :clj)
+  ;;=> {:exts [:clj], :mime \"text/x-clojure\", :tags [:editor.clj :editor.clojure], :name \"Clojure\"}
+  ```"
+  [ext]
   (let [exts (:exts @files-obj)
         types (:types @files-obj)]
     (-> exts (get ext) types)))
 
-(defn ext->mode [ext]
+(defn ext->mode
+  "Extracts the `:mime` information from `ext`, which must be a keyword.
+
+  Example:
+  ```
+  (ext->mode :txt)  ;;=> \"plaintext\"
+
+  (ext->mode :cljs) ;;=> \"text/x-clojurescript\"
+
+  (ext->mode :clj)  ;;=> \"text/x-clojure\"
+  ```"
+  [ext]
   (:mime (ext->type ext)))
 
-(defn path->type [path]
+(defn path->type
+  "Given a `path`, returns type information if a file. Returns an empty string if `path` is a directory.
+
+  Example:
+  ```
+  (path->type \"/foo/bar/baz.txt\")
+  ;;=> {:exts [:txt], :mime \"plaintext\", :tags [:editor.plaintext], :name \"Plain Text\"}
+
+  (path->type \"foo.cljs\")
+  ;;=> {:exts [:cljs], :mime \"text/x-clojurescript\", :tags [:editor.cljs :editor.clojurescript], :name \"ClojureScript\"}
+
+  (path->type \"foo.clj\")
+  ;;=> {:exts [:clj], :mime \"text/x-clojure\", :tags [:editor.clj :editor.clojure], :name \"Clojure\"}
+
+  (path->type \"/foo/bar/\")
+  ;;=> \"\" ; No type information is returned as it is a directory.
+  ```"
+  [path]
   (->> path
        get-file-parts
        (map #(ext->type (keyword %)))
        (remove nil?)
        first))
 
-(defn path->mode [path]
+(defn path->mode
+  "Given a `path`, returns mime information.
+
+  Example:
+  ```
+  (path->mode \"/foo/bar/baz.txt\") ;;=> \"plaintext\"
+
+  (path->mode \"foo.cljs\")         ;;=> \"text/x-clojurescript\"
+
+  (path->mode \"foo.clj\")          ;;=> \"text/x-clojure\"
+
+  (path->mode \"foo\")              ;;=> \"\"
+  ```"
+  [path]
   (->> path
        get-file-parts
        (map #(ext->mode (keyword %)))
@@ -135,27 +246,51 @@
       (not n) "\r\n"
       :else "\n")))
 
-(defn exists? [path]
+(defn exists?
+  "True if `path` exists on filesystem."
+  [path]
   (.existsSync fs path))
 
-(defn stats [path]
+(defn stats
+  "If `path` exists then returns [fs.Stats](https://nodejs.org/api/fs.html#fs_class_fs_stats) instance."
+  [path]
   (when (exists? path)
     (.statSync fs path)))
 
-(defn dir? [path]
+(defn dir?
+  "True if `path` corresponds to a directory that exists."
+  [path]
   (when (exists? path)
     (let [stat (.statSync fs path)]
       (.isDirectory stat))))
 
-(defn file? [path]
+(defn file?
+  "True if `path` corresponds to a file that exists."
+  [path]
   (when (exists? path)
     (let [stat (.statSync fs path)]
       (.isFile stat))))
 
-(defn absolute? [path]
+(defn absolute?
+  "True if `path` is formatted as an absolute filepath. False otherwise.
+  Does not check if `path` exists or otherwise valid.
+
+  Example:
+  ```
+  (absolute? \"/foo/bar/baz\")     ;;=> true
+
+  (absolute? \"/foo/bar/baz.txt\") ;;=> true
+
+  (absolute? \"./foo/bar\")        ;;=> false
+
+  (absolute? \"foo/bar\")          ;;=> false
+  ```"
+  [path]
   (boolean (re-seq #"^[\\\/]|([\w]+:[\\\/])" path)))
 
-(defn writable? [path]
+(defn writable?
+  "Returns 7, 6, 3, or 2 based on file permissions. `path` must exist."
+  [path]
   (let [perm (-> (.statSync fs path)
                  (.mode.toString 8)
                  (js/parseInt 10)
@@ -163,23 +298,55 @@
         perm (subs perm (- (count perm) 3))]
     (#{"7" "6" "3" "2"} (first perm))))
 
-(defn resolve [base cur]
+(defn resolve
+  "See [path.resolve](https://nodejs.org/api/path.html#path_path_resolve_path).
+
+  Example:
+  ```
+  (resolve \"/\" \"/home/user\")   ;;=> \"/home/user\"
+
+  (resolve \"/foo\" \"./bar/baz\") ;;=> \"/foo/bar/baz\"
+
+  (resolve \"./\" \"codox\")       ;;=> \"/home/user/dev/LightTable/codox\"
+  ```"
+  [base cur]
   (.resolve fpath base cur))
 
-(defn real-path [c]
+(defn real-path
+  "Returns the canonicalized absolute pathname, expanding symbolic links.
+
+  Example:
+
+  Assume current directory is `/foo/bar/` and `/foo/bar/baz` exists too.
+  ```
+  (real-path \"./\")           ;;=> \"/foo/bar/\"
+
+  (real-path \".././bar/baz\") ;;=> \"/foo/bar/baz/\"
+  ```"
+  [c]
   (.realpathSync fs c))
 
-(defn- ->file|dir [path f]
+(defn- ->file|dir
+  "If `path` and `f` together form a valid directory, then `f` is returned as a directory. Otherwise, `f` is returned as a file
+
+  Example:
+  ```
+  (->file|dir \"/foo/\" \"bar.txt\") ;;=> \"bar.txt\"
+
+  (->file|dir \"./foo/\" \"bar/\")   ;;=> \"bar/\"
+  ```"
+  [path f]
   (if (dir? (str path separator f))
     (str f separator)
     (str f)))
 
 (defn- bomless-read [path]
+  "Reads file at `path`, removes occurrences of `\uFEFF`, then returns modified result."
   (let [content (.readFileSync fs path "utf-8")]
     (string/replace content "\uFEFF" "")))
 
 (defn open
-  "Open file and in callback return map with file's content in :content"
+  "Open file and in callback return map with file's content in `:content`"
   [path cb]
   (try
     (let [content (bomless-read path)]
@@ -195,7 +362,7 @@
       (when cb (cb nil e)))))
 
 (defn open-sync
-  "Open file and return map with file's content in :content"
+  "Open file and return map with file's content in `:content`."
   [path]
   (try
     (let [content (bomless-read path)]
@@ -211,7 +378,7 @@
       nil)))
 
 (defn save
-  "Save path with given content. Optional callback called after save"
+  "Save `path` with given `content`. Optional callback called after save."
   [path content & [cb]]
   (try
     (.writeFileSync fs path content)
@@ -222,7 +389,7 @@
       (when cb (cb e)))))
 
 (defn append
-  "Append content to path. Optional callback called after append"
+  "Append `content` to `path`. Optional callback called after append."
   [path content & [cb]]
   (try
     (.appendFileSync fs path content)
@@ -232,39 +399,43 @@
       (object/raise files-obj :files.save.error path e)
       (when cb (cb e)))))
 
-(defn trash! [path]
+(defn trash!
+  "Move file to trash and returns boolean status."
+  [path]
   (.moveItemTotrash electron-shell path))
 
 (defn delete!
-  "Delete file or directory"
+  "Delete file or directory from filesystem."
   [path]
   (if (dir? path)
     (.rm shell "-rf" path)
     (.unlinkSync fs path)))
 
 (defn move!
-  "Move file or directory to given path"
+  "Move file or directory to given `path`."
   [from to]
   (.renameSync fs from to))
 
 (defn copy
-  "Copy file or directory to given path"
+  "Copy file or directory to given `path`."
   [from to]
   (if (dir? from)
     (.cp shell "-R" from to)
     (save to (:content (open-sync from)))))
 
 (defn mkdir
-  "Make given directory"
+  "Make given directory."
   [path]
   (.mkdirSync fs path))
 
 (defn parent
-  "Return directory of path"
+  "Return directory of `path`."
   [path]
 	(.dirname fpath path))
 
-(defn- next-available-name [path]
+(defn- next-available-name
+  "Given a `path`, if it already exists then append a digit (starts at 1 and increments after) to the end of `path` and check again."
+  [path]
   (if-not (exists? path)
     path
     (let [ext (ext path)
@@ -277,7 +448,7 @@
           (recur (inc x) (join p (str name (inc x) (when ext (str "." ext))))))))))
 
 (defn ls
-  "Return directory's files"
+  "Return directory's files."
   ([path] (ls path nil))
   ([path cb]
    (try
@@ -293,8 +464,8 @@
 (defn ls-sync
   "Return directory's files applying ignore-pattern. Takes map of options with keys:
 
-  * :files - When set only returns files
-  * :dirs - When set only return directories"
+  * `:files` - When set only returns files
+  * `:dirs` - When set only return directories"
   [path opts]
   (try
     (let [fs (remove #(re-seq ignore-pattern %) (map (partial ->file|dir path) (.readdirSync fs path)))]
@@ -306,7 +477,7 @@
       (js/lt.objs.console.error e))))
 
 (defn full-path-ls
-  "Return directory's files as full paths"
+  "Return directory's files as full paths."
   [path]
   (try
     (doall (map (partial join path) (.readdirSync fs path)))
@@ -314,7 +485,7 @@
       (js/lt.objs.console.error e))))
 
 (defn dirs
-  "Return directory's directories"
+  "Return directory's directories."
   [path]
   (try
     (filter dir? (map (partial join path) (.readdirSync fs path)))
@@ -322,7 +493,7 @@
       (js/lt.objs.console.error e))))
 
 (defn home
-  "Return users' home directory (e.g. ~/) or path under it"
+  "Return users' home directory (e.g. ~/) or path under it."
   ([] (home nil))
   ([path]
    (let [h (if (= js/process.platform "win32")
@@ -331,14 +502,14 @@
      (join h (or path separator)))))
 
 (defn lt-home
-  "Return LT's home directory"
+  "Return LT's home directory."
   ([] load/dir)
   ([path]
    (join (lt-home) path)))
 
 (defn lt-user-dir
-  "Return LT's user directory. Used for storing user-related content e.g.
-  settings, plugins, logs and caches"
+  "Return LT's user directory. Used for storing user-related content (e.g.,
+  settings, plugins, logs, and caches)."
   ([] (lt-user-dir ""))
   ([path]
    (if js/process.env.LT_USER_DIR
@@ -346,8 +517,8 @@
      (join data-path path))))
 
 (defn walk-up-find
-  "Starting at start path, walk up parent directories and return first path
-  whose basename matches find"
+  "Starting at `start` path, walk up parent directories and return first path
+  whose basename matches find."
   [start find]
   (let [roots (get-roots)]
     (loop [cur start
@@ -360,7 +531,9 @@
           (join cur find)
           (recur (parent cur) cur))))))
 
-(defn relative [a b]
+(defn relative
+  "Returns a relative path, if there is one, from `a` to `b`."
+  [a b]
   (.relative fpath a b))
 
 (defn- ->name|path [f & [rel]]
@@ -377,7 +550,19 @@
                segs)]
     (vec (map #(str % separator) segs))))
 
-(defn filter-walk [func path]
+(defn filter-walk
+  "Returns files and directories under `path` where `func` returns true.
+
+  Example:
+  ```
+  (filter-walk
+    (fn [x] (= (basename x) \"LightTable\"))
+    \"/home/sbauer/dev/LightTable/\")
+  ;;=> (\"/home/sbauer/dev/LightTable/builds/lighttable-0.8.1-linux/LightTable\"
+       \"/home/sbauer/dev/LightTable/.git/refs/remotes/LightTable\"
+       \"/home/sbauer/dev/LightTable/.git/logs/refs/remotes/LightTable\")
+  ```"
+  [func path]
   (loop [to-walk (dirs path)
          found (filterv func (full-path-ls path))]
     (if-not (seq to-walk)


### PR DESCRIPTION
This pull request adds documentation to editor and files namespaces. 

One thing to note is that this pull request enables markdown for Codox. This means toggling docs within LightTable will likely cause the markdown syntax to be rendered. A follow up issue #2250 has been opened for future work to address this.