### PR TITLE
Add info about whole-file eval for Light Table source files to 'committers' doc.

### DIFF
--- a/doc/for-committers.md
+++ b/doc/for-committers.md
@@ -39,6 +39,14 @@ Allows us to build cross platfrom desktop apps. See [Electron guide](electron-gu
 
 ## Other
 
+### Running Light Table Code in Light Table
+
+Generally, and unless you know what you're doing, do *not* eval entire files of the Light Table source; eval individual forms.
+
+As Gabriel explains in [this comment](https://github.com/LightTable/LightTable/issues/2170#issuecomment-201835808) in [issue #2170](https://github.com/LightTable/LightTable/issues/2170):
+
+> Depending on the file you're re-evaling, a whole file re-eval often redefines core LT object types and recreates LT objects. This can have dire consequences in some files e.g. re-evaling object.cljs will freeze LT as LT no longer has any objects defined. In the case of editor.cljs, if you comment the editor object type and do a file re-eval, you don't see errors. My suggestion is to stick to evaling forms when exploring LT and only do a file eval as you learn more of the codebase and understand the implications of a given file eval. I can add a brief description about this in the wiki or doc/for-committers.md if you think that'd be helpful to others.
+
 ### Code Conventions
 
 * See the LightTable Style Guide.


### PR DESCRIPTION
See #2254 and #2170, which inspired the former.