### PR TITLE
Document functions of util namespaces - closes #2264

### DIFF
--- a/src/lt/util/dom.cljs
+++ b/src/lt/util/dom.cljs
@@ -1,8 +1,9 @@
 (ns lt.util.dom
-  "Provide DOM related fns"
+  "Provide DOM related functions."
   (:refer-clojure :exclude [parents remove next val empty]))
 
 (defn lazy-nl-via-item
+  "Return lazy seq of NodeList."
   ([nl] (lazy-nl-via-item nl 0))
   ([nl n] (when (< n (. nl -length))
             (lazy-seq
@@ -37,92 +38,228 @@
     ([this n not-found]
      (or (.item this n) not-found))))
 
-(defn text-node [text]
+(defn text-node
+  "Create a text node containing string `text`."
+  [text]
   (js/document.createTextNode text))
 
 (defn $$
+  "Returns a NodeList of all elements within `elem` that match `query`.
+
+  If `elem` is not specified then the entire document is used."
   ([query] ($$ query js/document))
   ([query elem] (.querySelectorAll elem (name query))))
 
 (defn $
+  "Returns the first element found within `elem` that matches `query`.
+
+  If `elem` is not specified then the entire document is used.
+
+  Example:
+  ```
+  ;; Assume there exists a div such as:
+  ;; <div class=\"tabsets\">
+
+  ($ \"div .tabsets\")
+  ;;=> #<[object HTMLDivElement]>
+  ```"
   ([query]  ($ query js/document))
   ([query elem] (.querySelector elem (name query))))
 
-(defn append [parent child]
+(defn append
+  "Append `child` to the `parent` as a child node. If `child` already exists
+  as a node then it is moved to the new location.
+
+  Returns `parent`."
+  [parent child]
   (.appendChild parent child)
   parent)
 
-(defn prepend [parent child]
+(defn prepend
+  "Insert `child` as the first child node of `parent`, if there already exist children nodes.
+  Otherwise, [[append]] `child`."
+  [parent child]
   (if (.-firstChild parent)
     (.insertBefore parent child (.-firstChild parent))
     (append parent child)))
 
-(defn add-class [elem class]
+(defn add-class
+  "Add `class` to the classList of `elem`."
+  [elem class]
   (when (and elem (not (empty? (name class))))
     (.add (.-classList elem) (name class))))
 
-(defn remove-class [elem class]
+(defn remove-class
+  "Remove `class` from the classList of `elem`."
+  [elem class]
   (when (and elem (not (empty? (name class))))
     (.remove (.-classList elem) (name class))))
 
-(defn has-class? [elem class]
+(defn has-class?
+  "True when `elem` has `class` in its classList."
+  [elem class]
   (when (and elem (not (empty? (name class))))
     (.contains (.-classList elem) (name class))))
 
-(defn toggle-class [elem class]
+(defn toggle-class
+  "If `elem` has `class` then remove `class`. Otherwise, `class` is added to `elem`."
+  [elem class]
   (if (has-class? elem class)
     (remove-class elem class)
     (add-class elem class)))
 
-(defn set-css [elem things]
+(defn set-css
+  "Add each key-value pair in `things` to `elem`'s style.
+
+  Returns `nil`, if change was successful.
+
+  Example:
+  ```
+  ;; Assume there exists a div such as:
+  ;; <div class=\"tabsets\" style=\"bottom: 34px;\">
+
+  ;; Returns nil, but makes the change.
+  (dom/set-css ($ \"div\") {\"bottom\" \"50px\"})
+  ;;=> nil
+  ;; div is now: <div class=\"tabsets\" style=\"bottom: 50px;\">
+  ```"
+  [elem things]
   (doseq [[k v] things]
     (aset (.-style elem) (name k) (if (keyword? v) (name v) v))))
 
-(defn css [elem things]
+(defn css
+  "If `things` is a map, sets the CSS of `elem` via [[set-css]]. Otherwise,
+  returns what is located at key `things` in `elem`.
+
+  Example:
+  ```
+  ;; Assume there exists a div such as:
+  ;; <div class=\"tabsets\" style=\"bottom: 34px;\">
+
+  (css ($ \"div .tabsets\") :bottom)
+  ;;=> \"34px\"
+
+  ;; Returns nil, but makes the change.
+  (css ($ \"div .tabsets\") {\"bottom\" \"50px\"})
+  ;;=> nil
+
+  (css ($ \"div .tabsets\") \"bottom\")
+  ;;=> \"50px\"
+  ```"
+  [elem things]
   (let [things (if (= js/Object (type things))
-            (js->clj things)
-            things)]
+                 (js->clj things)
+                 things)]
     (if (map? things)
       (set-css elem things)
       (aget (.-style elem) (name things)))))
 
-(defn set-attr [elem things]
+(defn set-attr
+  "Add each key-value pair in `things` to `elem`'s attributes.
+
+  Returns `nil`, if change was successful.
+
+  Example:
+  ```
+  ;; Assume there exists a div such as:
+  ;; <div class=\"tabsets\">
+
+  ;; Returns nil, but makes the change.
+  (dom/set-attr ($ \"div .tabsets\") {:draggable \"true\"})
+  ;;=> nil
+  ;; div is now: <div class=\"tabsets\" draggable=\"true\";>
+  ```"
+  [elem things]
   (doseq [[k v] things]
     (.setAttribute elem (name k) (if (keyword? v) (name v) v))))
 
-(defn attr [elem things]
+(defn attr
+  "If `things` is a map, sets the attributes of `elem` via [[set-attr]]. Otherwise, returns
+  what is located at key `things` in `elem`.
+
+  Example:
+  ```
+  ;; Assume there exists a div such as:
+  ;; <div class=\"tabsets\" draggable=\"true\";>
+
+  (attr ($ \"div .tabsets\") \"draggable\")
+  ;;=> \"true\"
+
+  ;; Returns nil, but makes the change.
+  (attr ($ \"div .tabsets\") {\"draggable\" \"false\"})
+  ;;=> nil
+
+  (attr ($ \"div .tabsets\") \"draggable\")
+  ;;=> \"false\"
+  ```"
+  [elem things]
   (if (map? things)
     (set-attr elem things)
     (.getAttribute elem (name things))))
 
-(defn parent [elem]
+(defn parent
+  "Return the parent node of `elem`.
+
+  Note: using `parent` on the document node will result in a type error.
+
+  Example:
+  ```
+  (parent ($ \"body\"))
+  ;;=> #<[object HTMLHtmlElement]>
+
+  (.-nodeName (parent ($ \"body\")))
+  ;;=> \"HTML\"
+  ```"
+  [elem]
   (.-parentNode elem))
 
-(defn children [elem]
+(defn children
+  "Return the child nodes of `elem`."
+  [elem]
   (.-children elem))
 
-(defn remove [elem]
+(defn remove
+  "Remove `elem` from the DOM tree."
+  [elem]
   (when-let [p (parent elem)]
     (.removeChild p elem)))
 
-(defn empty [elem]
+(defn empty
+  "Sets the inner HTML of `elem` to an empty string."
+  [elem]
   (set! (.-innerHTML elem) ""))
 
-(defn val [elem & [v]]
+(defn val
+  "If `v` is provided then set the value of `elem` to `v`. Otherwise, return the
+  current value of `elem`."
+  [elem & [v]]
   (if-not v
     (.-value elem)
     (set! (.-value elem) v)))
 
-(defn prevent [e]
+(defn prevent
+  "Cancel event `e`, if it is cancelable. Does not stop further propagation.
+
+  See [[stop-propagation]]."
+  [e]
   (.preventDefault e))
 
-(defn stop-propagation [e]
+(defn stop-propagation
+  "Stop further propagation of event `e`.
+
+  See [[prevent]]."
+  [e]
   (.stopPropagation e))
 
-(defn siblings [elem]
+(defn siblings
+  "Return child nodes of `elem`'s parent."
+  [elem]
   (.-children (parent elem)))
 
-(defn parents [elem sel]
+(defn parents
+  "Starting with `elem`'s immediate parent going up, returns first parent of
+  `elem` that has a selector matching `sel` or `nil` if no match is found."
+  [elem sel]
   (let [root (parent ($ :body))]
     (loop [p (parent elem)]
       (when (and p
@@ -131,92 +268,169 @@
           p
           (recur (parent p)))))))
 
-(defn next [elem]
+(defn next
+  "Returns the next element at the same level of `elem` in the DOM tree.
+  `nil` if there are no siblings."
+  [elem]
   (.-nextElementSibling elem))
 
-(defn before [elem neue]
+(defn before
+  "Insert element `neue` into `elem`'s parent in the position before `elem`.
+
+  See [[after]]."
+  [elem neue]
   (.insertBefore (parent elem) neue elem))
 
-(defn after [elem neue]
+(defn after
+  "Insert element `neue` into `elem`'s parent in the position after `elem`.
+
+  See [[before]]."
+  [elem neue]
   (if-let [n (next elem)]
     (before n neue)
     (append (parent elem) neue)))
 
-(defn replace-with [orig neue]
+(defn replace-with
+  "Replace `orig` with `neue`."
+  [orig neue]
   (when-let [p (parent orig)]
     (.replaceChild p neue orig)))
 
-(defn height [elem]
+(defn height
+  "Returns the height of the visible area for `elem`, in pixels. The value
+  contains the height with the padding, but it does not include the scrollBar,
+  border, and the margin."
+  [elem]
   (.-clientHeight elem))
 
-(defn width [elem]
+(defn width
+  "Returns the width of the visible area for `elem`, in pixels. The value
+  contains the width with the padding, but it does not include the scrollBar,
+  border, and the margin."
+  [elem]
   (.-clientWidth elem))
 
-(defn scroll-width [elem]
+(defn scroll-width
+  "Returns, in pixels, whichever is greater, the width of the content within
+  `elem` or the width of `elem` itself."
+  [elem]
   (.-scrollWidth elem))
 
-(defn offset-top [elem]
+(defn offset-top
+  "Return, in pixels, the offset of `elem` relative to the top of the
+  parent."
+  [elem]
   (.-offsetTop elem))
 
-(defn scroll-top [elem & [v]]
+(defn scroll-top
+  "Returns or sets the scrollTop value of `elem` depending on if `v` was
+  provided."
+  [elem & [v]]
   (if-not v
     (.-scrollTop elem)
     (set! (.-scrollTop elem) v)))
 
-(defn top [elem]
+(defn top
+  "Return the `:top` style of `elem`."
+  [elem]
   (css elem :top))
 
-(defn bottom [elem]
+(defn bottom
+  "Return the `:bottom` style of `elem`."
+  [elem]
   (css elem :bottom))
 
-(defn left [elem]
+(defn left
+  "Return the `:left` style of `elem`."
+  [elem]
   (css elem :left))
 
-(defn right [elem]
+(defn right
+  "Return the `:right` style of `elem`."
+  [elem]
   (css elem :right))
 
-(defn html [elem & [h]]
+(defn html
+  "Return the inner HTML of `elem` or set the inner HTML to `h`."
+  [elem & [h]]
   (if-not h
     (.-innerHTML elem)
     (set! (.-innerHTML elem) h)))
 
-(defn ->ev [ev]
+(defn ->ev
+  "Convert `ev` to string."
+  [ev]
   (str (name ev)))
 
-(defn trigger [elem ev & [opts]]
+(defn trigger
+  "Trigger a HTMLEvents event named `ev` on `elem` with `opts` set on the
+  event."
+  [elem ev & [opts]]
   (let [e (.createEvent js/document "HTMLEvents")]
     (.initEvent e (name ev) true true)
     (set! (.-opts e) opts)
     (.dispatchEvent elem e)))
 
-(defn on [elem ev cb]
+(defn on
+  "Add event listener named `ev` on `elem` with callback function `cb`."
+  [elem ev cb]
   (.addEventListener elem (->ev ev) cb))
 
-(defn off [elem ev cb]
+(defn off
+  "Remove event listener named `ev` on `elem` with callback function `cb`."
+  [elem ev cb]
   (.removeEventListener elem (->ev ev) cb))
 
-(defn on* [elem evs]
+(defn on*
+  "Add multiple event listeners to `elem`.
+
+  `evs` should be a map of the form `{:ev cb}` where `:ev` is the name and
+  `cb` the callback function."
+  [elem evs]
   (doseq [[ev cb] evs]
     (.addEventListener elem (->ev ev) cb)))
 
-(defn active-element []
+(defn active-element
+  "Return the active element of the document.
+
+  An active element does not necessarily have focus, but an element with focus
+  is always the active element in a document."
+  []
   (.-activeElement js/document))
 
-(defn focus [elem]
+(defn focus
+  "Sets focus on `elem`."
+  [elem]
   (.focus elem))
 
-(defn blur [elem]
+(defn blur
+  "Remove focus from `elem`."
+  [elem]
   (.blur elem))
 
-(defn selection [elem start stop dir]
+(defn selection
+  "Set the current selection range on `elem` with `start` and `stop` being the
+  indexes which respectively contain the first and last characters of the
+  selection.
+
+  `dir` can be used to set the direction in which selection occurs."
+  [elem start stop dir]
   (.setSelectionRange elem start stop dir))
 
-(defn make [str]
+(defn make
+  "Create div containing `str` as inner HTML. Returns HTMLCollection of
+  resulting div.
+
+  See [[children]]."
+  [str]
   (let [d (.createElement js/document "div")]
     (html d str)
     (children d)))
 
-(defn index [e]
+(defn index
+  "Returns the index of element `e`, which is where `e` is located inside of its
+  parent's list of children, or -1 if there is no parent."
+  [e]
   (let [p (parent e)
         c (if p (children p) (array))
         len (.-length c)]
@@ -229,12 +443,16 @@
             i
             (recur (inc i))))))))
 
-(defn ready [func]
+(defn ready
+  "Trigger `func` when `:DOMContentLoaded` fires on the document."
+  [func]
   (on js/document :DOMContentLoaded func))
 
-(defn fragment [items]
+(defn fragment
+  "Create and return a document fragment with `items` appended to it as
+  children."
+  [items]
   (let [frag (.createDocumentFragment js/document)]
     (doseq [i items]
       (.appendChild frag i))
     frag))
-

--- a/src/lt/util/events.cljs
+++ b/src/lt/util/events.cljs
@@ -1,6 +1,9 @@
 (ns lt.util.events
-  "Provide DOM event related fns")
+  "Provide DOM event related functions.")
 
 (defn capture
+  "Add function `handler` to trigger when event listener `ev` fires on `elem`.
+
+  If `elem` is not provided then the event `ev` and its `handler` are bound to the document."
   ([ev handler] (capture js/document ev handler))
   ([elem ev handler] (.addEventListener elem (name ev) handler true)))

--- a/src/lt/util/ipc.cljs
+++ b/src/lt/util/ipc.cljs
@@ -1,17 +1,13 @@
 (ns lt.util.ipc
   "Util functions for the ipc renderer - https://github.com/atom/electron/blob/master/docs/api/ipc-renderer.md")
 
-(def ipc (js/require "ipc"))
+(def ipc "Provides access to the ipc renderer." (js/require "ipc"))
 
-(defn send
-  "Delegates to ipc.send which asynchronously sends args to the browser process's channel."
-  [channel & args]
-  (apply (.-send ipc) channel (clj->js args)))
+;; `send` and `on` are declared here with their bodies defined later as otherwise Codox will use the
+;; redefined `send` and `on` in the below when block instead.
+(declare send)
 
-(defn on
-  "Delegates to ipc.on which defines a callback to fire for the given channel."
-  [channel cb]
-  (.on ipc channel cb))
+(declare on)
 
 ;; Set $IPC_DEBUG to debug incoming and outgoing ipc messages for the renderer process
 (when (aget js/process.env "IPC_DEBUG")
@@ -24,3 +20,13 @@
               (old-on channel (fn [& args]
                                 (prn "->RENDERER" channel args)
                                 (apply cb args)))))))
+
+(defn send
+  "Delegates to ipc.send, which asynchronously sends args to the browser process's channel."
+  [channel & args]
+  (apply (.-send ipc) channel (clj->js args)))
+
+(defn on
+  "Delegates to ipc.on, which defines a callback to fire for the given channel."
+  [channel cb]
+  (.on ipc channel cb))

--- a/src/lt/util/js.cljs
+++ b/src/lt/util/js.cljs
@@ -1,37 +1,70 @@
 (ns lt.util.js
-  "Provide misc js related fns")
+  "Provide misc Javascript related functions.")
 
-(defn every [ms func]
+(defn every
+  "Execute `func` every `ms` milliseconds."
+  [ms func]
   (js/setInterval func ms))
 
-(defn wait [ms func]
+(defn wait
+  "Wait `ms` milliseconds before executing `func`."
+  [ms func]
   (js/setTimeout func ms))
 
-(defn now []
+(defn now
+  "Return the current time in milliseconds starting from the Unix epoch."
+  []
   (.getTime (js/Date.)))
 
-(defn toggler [cur op op2]
+(defn toggler
+  "If `cur` equals `op` then return `op2`. Otherwise return `op`."
+  [cur op op2]
   (if (= cur op)
     op2
     op))
 
-(defn debounce [ts func]
+(defn debounce
+  "Debounce execution of `func` with a delay of `ts` milliseconds.
+
+  In other words, returns a new function that executes `func` only once
+  after `ts` milliseconds regardless the number of times the new function is called
+  during the `ts` milliseconds.
+
+  See [[throttle]]."
+  [ts func]
+  ;; For js/Cowboy, see deploy/core/node_modules/lighttable/throttle.js
   (.debounce js/Cowboy ts func))
 
-(defn throttle [ts func]
+(defn throttle
+  "Throttle execution of `func` with a delay of `ts` milliseconds.
+
+  In other words, returns a new function that executes `func` no more than
+  once every `ts` milliseconds.
+
+  See [[debounce]]."
+  [ts func]
+  ;; For js/Cowboy, see deploy/core/node_modules/lighttable/throttle.js
   (.throttle js/Cowboy ts func))
 
-(defn ->clj [data]
+(defn ->clj
+  "Convert JSON `data` to ClojureScript with keywords enabled.
+
+  See [js->clj](http://cljs.github.io/api/cljs.core/js-GTclj)."
+  [data]
   (js->clj data :keywordize-keys true))
 
-(def entities {"&" "&amp;"
-               "<" "&lt;"
-               ">" "&gt;"
-               "\"" "&quot;"
-               "'" "&#39;"
-               "/" "&#x2F;"})
+(def entities
+  "Map of entities, such as `&`, to their corresponding character reference."
+  {"&" "&amp;"
+   "<" "&lt;"
+   ">" "&gt;"
+   "\"" "&quot;"
+   "'" "&#39;"
+   "/" "&#x2F;"})
 
-(defn escape [str]
+(defn escape
+  "Replace characters in `str` that are in [[entities]] with their escaped equivalent."
+  [str]
   (when str
     (.replace str (js/RegExp. "[&<>\"'/]" "g") (fn [s]
                                                  (entities s)))))

--- a/src/lt/util/kahn.cljs
+++ b/src/lt/util/kahn.cljs
@@ -1,36 +1,41 @@
 (ns lt.util.kahn
-  "Provide a Khan sort"
+  "Provide a [Khan sort](https://en.wikipedia.org/wiki/Topological_sorting#Kahn.27s_algorithm)."
   (:require [clojure.set :as set :refer [difference union intersection]]))
 
 (defn without
-  "Returns set s with x removed."
+  "Returns set `s` with `x` removed."
   [s x] (difference s #{x}))
 
 (defn take-1
-  "Returns the pair [element, s'] where s' is set s with element removed."
+  "Returns the pair `[element, s']` where `s'` is set `s` with `element` removed."
   [s] {:pre [(not (empty? s))]}
   (let [item (first s)]
     [item (without s item)]))
 
 (defn no-incoming
-  "Returns the set of nodes in graph g for which there are no incoming
-  edges, where g is a map of nodes to sets of nodes."
+  "Returns the set of nodes in graph `g` for which there are no incoming
+  edges, where `g` is a map of nodes to sets of nodes."
   [g]
   (let [nodes (set (keys g))
         have-incoming (apply union (vals g))]
     (difference nodes have-incoming)))
 
 (defn normalize
-  "Returns g with empty outgoing edges added for nodes with incoming
-  edges only.  Example: {:a #{:b}} => {:a #{:b}, :b #{}}"
+  "Returns `g` with empty outgoing edges added for nodes with incoming
+  edges only.
+
+  Example:
+  ```
+  (normalize {:a #{:b}}) ;;=> {:a #{:b}, :b #{}}
+  ```"
   [g]
   (let [have-incoming (apply union (vals g))]
     (reduce #(if (get % %2) % (assoc % %2 #{})) g have-incoming)))
 
 (defn kahn-sort
-  "Proposes a topological sort for directed graph g using Kahn's
-   algorithm, where g is a map of nodes to sets of nodes. If g is
-   cyclic, returns nil."
+  "Proposes a topological sort for directed graph `g` using Kahn's
+   algorithm, where `g` is a map of nodes to sets of nodes. If `g` is
+   cyclic, returns `nil`."
   ([g]
      (kahn-sort (normalize g) [] (no-incoming g)))
   ([g l s]

--- a/src/lt/util/load.cljs
+++ b/src/lt/util/load.cljs
@@ -1,23 +1,44 @@
 (ns lt.util.load
-  "Provide fns to load js, css and node module assets into LT"
+  "Provide functions to load js, css and node module assets into LT."
   (:require [clojure.string :as string]))
 
-(def fpath (js/require "path"))
-(def fs (js/require "fs"))
+(def fpath "Provides access to Node/Electron [path library](https://nodejs.org/api/path.html)." (js/require "path"))
+(def fs "Provides access to Node/Electron [fs library](https://nodejs.org/api/fs.html)." (js/require "fs"))
 
-(def dir (str js/__dirname "/.."))
+(def dir "Directory where Light Table is being executed." (str js/__dirname "/.."))
 
-(def ^:dynamic *force-reload* false)
+(def ^:dynamic *force-reload* "When true, various parts of Light Table will reload."
+  false)
 
-(def separator (.-sep fpath))
+(def separator
+  "Current platform-specific file separator."
+  (.-sep fpath))
 
-(defn absolute? [path]
+(defn absolute?
+  "True if `path` is formatted as an absolute filepath. False otherwise.
+  Does not check if `path` exists or is otherwise valid.
+
+  Example:
+  ```
+  (absolute? \"/foo/bar/baz\")     ;;=> true
+
+  (absolute? \"/foo/bar/baz.txt\") ;;=> true
+
+  (absolute? \"./foo/bar\")        ;;=> false
+
+  (absolute? \"foo/bar\")          ;;=> false
+  ```"
+  [path]
   (boolean (re-seq #"^\s*[\\\/]|([\w]+:[\\\/])" path)))
 
-(defn node-module [path]
+(defn node-module
+  "Requires Light Table's bundled node modules located at `path`."
+  [path]
   (js/require (str dir "/core/node_modules/" path)))
 
-(defn- abs-source-mapping-url [code file]
+(defn- abs-source-mapping-url
+  "Converts source mapping to use absolute paths for URLs. Also converts `\\` to `/` in order to maintain compatibility with Windows."
+  [code file]
   (if-let [path-to-source-map (second (re-find #"\n//# sourceMappingURL=(.*\.map)" code))]
     (if-not (absolute? path-to-source-map)
       (let [abs-path-to-source-map (string/replace (.join fpath (.dirname fpath file) path-to-source-map) "\\" "/")
@@ -34,6 +55,9 @@
       (str "\n\n//# sourceURL="  (js/encodeURI file))))
 
 (defn js
+  "Loads `file`, into Light Table and evaluates it.
+
+  If `sync` is not provided then it defaults to `false`. If `sync` is truthy then `file` will be loaded synchronously."
   ([file] (js file false))
   ([file sync]
    (let [file (if-not (absolute? file)
@@ -47,18 +71,22 @@
                                             (js/window.eval (-> (.toString content)
                                                                 (prep file)))))))))
 
-(defn css [file]
-   (let [link (js/document.createElement "link")]
-     (set! (.-type link) "text/css")
-     (set! (.-rel link) "stylesheet")
-     (set! (.-href link) (if (absolute? file)
-                           (str "file://" file)
-                           file))
-     (js/document.head.appendChild link)
-     link))
+(defn css
+  "Loads `file` into Light Table as CSS. Returns the resulting link."
+  [file]
+  (let [link (js/document.createElement "link")]
+    (set! (.-type link) "text/css")
+    (set! (.-rel link) "stylesheet")
+    (set! (.-href link) (if (absolute? file)
+                          (str "file://" file)
+                          file))
+    (js/document.head.appendChild link)
+    link))
 
 
-(defn obj-exists? [s]
+(defn obj-exists?
+  "When string `s` corresponds to a Javascript object already existing in Light Table then return the found object."
+  [s]
   (loop [parts (string/split s ".")
          cur js/window]
     (if-not (first parts)
@@ -66,15 +94,23 @@
       (if-let [cur (aget cur (first parts))]
         (recur (rest parts) cur)))))
 
-(def provided #js {})
+(def provided
+  "An empty Javascript object."
+  #js {})
 
-(defn provided-ancestors [parent]
+(defn provided-ancestors
+  "Return the number of ancestors of `parent`."
+  [parent]
   (count (.filter (js/Object.keys provided) #(> (.indexOf % parent) -1))))
 
-(defn only-ancestors? [cur s]
+(defn only-ancestors?
+  "True if the number of keys is less than or equal to the number of ancestors found."
+  [cur s]
   (<= (.-length (js/Object.keys cur)) (provided-ancestors s)))
 
-(defn provided? [s]
+(defn provided?
+  "No usage was found in Light Table core and is a candidate for deprecation. Do not use."
+  [s]
   (if *force-reload*
     false
     (let [res (if (aget provided s)

--- a/src/lt/util/style.cljs
+++ b/src/lt/util/style.cljs
@@ -1,5 +1,14 @@
 (ns lt.util.style
-  "Provide style related fns")
+  "Provide style related functions.")
 
-(defn ->px [s]
-  (str (or s 0) "px")) 
+(defn ->px
+  "Appends \"px\" to `s`. If `s` is falsey then 0 is used.
+
+  Example:
+  ```
+  (->px 75)    ;;=> \"75px\"
+
+  (->px false) ;;=> \"0px\"
+  ```"
+  [s]
+  (str (or s 0) "px"))


### PR DESCRIPTION
This PR handles the documentation of the files under the util directory:

  - cljs.cljs
  - dom.cljs
  - events.cljs
  - ipc.cljs
  - js.cljs
  - kahn.cljs
  - load.cljs
  - style.cljs

One thing to consider is if we should adjust our project.clj to allow for these namespaces to be generated with Codox. Currently, we have only a small number of namespaces exposed.

See issue #2264 