### PR TITLE
Fix language docs sidebar from keeping focus when closed - fixes #2258

### DIFF
--- a/deploy/settings/default/default.behaviors
+++ b/deploy/settings/default/default.behaviors
@@ -517,6 +517,7 @@
 
  [:sidebar.docs.search :lt.plugins.doc/sidebar.doc.search.exec]
  [:sidebar.docs.search :lt.plugins.doc/doc.search.results]
+ [:sidebar.docs.search :lt.plugins.doc/focus-on-show]
  [:sidebar.docs.search :lt.plugins.doc/focus!]
  [:sidebar.docs.search :lt.plugins.doc/set-item]
  [:sidebar.docs.search :lt.plugins.doc/clear!]

--- a/src/lt/plugins/doc.cljs
+++ b/src/lt/plugins/doc.cljs
@@ -133,7 +133,7 @@
           (clients/send c (:trigger cur) {:search v} :only this))))))
 
 (defn ->val [this]
-  (dom/val (dom/$ :.search (object/->content this))))
+  (dom/val (dom/$ :input.search (object/->content this))))
 
 (defn grouped-items [results v prev]
   (let [normal (dom/fragment [])
@@ -199,10 +199,19 @@
                         (dom/prepend old exact)
                         (dom/append old normal))))
 
+(behavior ::focus-on-show
+          :triggers #{:show}
+          :reaction (fn [this]
+                      (object/raise this :focus!)))
+
 (behavior ::focus!
           :triggers #{:focus!}
           :reaction (fn [this]
-                      (dom/focus (dom/$ :input (object/->content this)))))
+                      (if-not (:active @this)
+                        (let [input (dom/$ :input (object/->content this))]
+                          (dom/focus input)
+                          (.select input))
+                        (object/raise (-> @this :active :options) :focus!))))
 
 (object/object* ::sidebar.doc.search
                 :tags #{:sidebar.docs.search}
@@ -230,8 +239,7 @@
               :desc "Docs: Search language docs"
               :exec (fn [force?]
                       (when doc-search
-                        (object/raise sidebar/rightbar :toggle doc-search {:force? force?})
-                        (object/raise doc-search :focus!))
+                        (object/raise sidebar/rightbar :toggle doc-search {:force? force?}))
                       )})
 
 (cmd/command {:command :docs.search.hide
@@ -239,7 +247,7 @@
               :hidden true
               :exec (fn [force?]
                       (when doc-search
-                        (object/raise sidebar/rightbar :close! doc-search))
+                        (object/raise sidebar/rightbar :close!))
                       )})
 
 (behavior ::init-doc-search


### PR DESCRIPTION
To test the fix for #2258, open a file, place the cursor within the file, access the language docs sidebar, then close the sidebar. Cursor should return to previous location. 

By default Ctrl shift d opens the language docs sidebar.