### PR TITLE
Add optional docstring to defui, behavior, and object - closes #2206

### DIFF
--- a/src/lt/object.cljs
+++ b/src/lt/object.cljs
@@ -226,7 +226,8 @@
   * :triggers - Set of object's triggers
   * :init - Init fn called when object is created. Fn's return value
             is hiccup html content and saved to :content
-  * :listeners (internal) - Map of triggers to vectors of behaviors"
+  * :listeners (internal) - Map of triggers to vectors of behaviors
+  * :doc - Equivalent to a traditional function docstring."
   [name & r]
   (-> (apply make-object* name r)
       (store-object*)


### PR DESCRIPTION
This pull request adds an optional docstring to `defui`, `behavior`, and `object` for issue #2206. It is viewable by the in-line doc command (Ctrl-D). The key to use is `:doc` for behaviors and objects. defui is similar to defn.

One caveat is that the docstrings for behaviors and objects will not appear in Codox. This should not be an issue as behaviors and objects do not currently appear in Codox either... Behaviors likely won't be visible in Codox unless their internal functions are made public, which is probably a bad idea. Objects have a similar issue.

Here are samples:

![object-docstring](https://cloud.githubusercontent.com/assets/2945386/19027716/141d2ca8-8901-11e6-82a8-889a780c2f6e.png)

![behavior-docstring](https://cloud.githubusercontent.com/assets/2945386/19027710/0fb2e9fa-8901-11e6-9649-65250a943ec9.png)

Do note, this issue does not deal with tags or triggers... so using Ctrl-D on trigger `:close!` rather than the behavior `::close!` will result in no docs found. I do not feel that adding logic to get behavior or object docstrings through tags or triggers will be feasible... but I am not certain - something to investigate in another issue!
