### PR TITLE
Remove unnecessary, and potentially dangerous, -f from delete! function.

### DIFF
--- a/src/lt/objs/files.cljs
+++ b/src/lt/objs/files.cljs
@@ -408,7 +408,7 @@
   "Delete file or directory from filesystem."
   [path]
   (if (dir? path)
-    (.rm shell "-rf" path)
+    (.rm shell "-r" path)
     (.unlinkSync fs path)))
 
 (defn move!


### PR DESCRIPTION
This PR removes the -f parameter from shell's rm command in files/delete!. As @cldwalker noticed, it is not needed and could be a potential source of trouble.