### PR TITLE
Prevent error when launching LT for the first time - fixes #2150

### DIFF
--- a/src/lt/objs/cache.cljs
+++ b/src/lt/objs/cache.cljs
@@ -10,6 +10,9 @@
 (def settings (atom {}))
 
 (defn on-disk [cb]
+  ;; We must ensure the file's existence before attempting to open it.
+  (when-not (files/file? settings-path)
+    (files/save settings-path {}))
   (files/open settings-path (fn [data]
                               (if-not (empty? data)
                                 (cb (reader/read-string (:content data)))


### PR DESCRIPTION
This PR makes sure `.../ltcache/default.clj` exists before attempting to open it and fixes issue #2150 

To test:

- Pull down this PR's branch
- Delete or move the default.clj in your LT user directory
- Build and launch LT
- Confirm there is no longer an error on startup