### PR TITLE
Allow build and start on MINGW (no cygwin required)

### DIFF
--- a/doc/developer-install.md
+++ b/doc/developer-install.md
@@ -11,9 +11,10 @@
 
 None. Skip to [Build](#build).
 
-### Windows
 
-Download [Cygwin](https://cygwin.com/install.html).
+### Windows - with Cygwin
+
+Download [Cygwin](https://cygwin.com/install.html). If you find Cygwin to much on your windows system, take a look at [building with Windows (using GIT)](#WindowsGit)
 
 You may need to change */etc/fstab* (path in Cygwin) to fix a directory permission error when building. Change this line:
 
@@ -32,6 +33,42 @@ Close and re-open Cygwin Terminal.
 The issue:
 
  - ["mkdir: cannot create directory" error running branch build on Windows 7 · Issue #1918 · LightTable/LightTable](https://github.com/LightTable/LightTable/issues/1918)
+
+
+### Windows - With GIT <a name="WindowsGit"></a>
+Preparations. Make sure you have git and node installed. Download the lein script (not lein.bat).
+
+1. Start bash.exe from the &lt;GITHOME&gt;/bin
+
+2. Test for necessary executables. Execute
+
+```bash
+$ where lein
+C:\Leiningen\lein
+C:\Leiningen\lein.bat
+
+$ where npm
+C:\Programme\NodeJS\npm
+C:\Programme\NodeJS\npm.bat
+
+$ where node
+C:\Programme\NodeJS\node.exe
+```
+
+All commands should yield a path like in the above example. If one of the commands returns with a *file not found* then add the path to the executable to the path:
+
+```bash
+$ where lein
+... not found ...
+
+$ export PATH=$PATH:/C/Leiningen
+
+$ where lein
+C:\Leiningen\lein
+C:\Leiningen\lein.bat
+```
+
+You are good to go! Continue with the [Build](#build).
 
 
 ### Linux

--- a/script/build-app.sh
+++ b/script/build-app.sh
@@ -30,6 +30,11 @@ elif [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
   RESOURCES="resources"
   PLATFORM_DIR="deploy/platform/win"
 
+elif [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
+  OS="windows"
+  RESOURCES="resources"
+  PLATFORM_DIR="deploy/platform/win"
+
 else
   echo "Cannot detect a supported OS."
   exit 1

--- a/script/light.sh
+++ b/script/light.sh
@@ -14,6 +14,8 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
   CLI="${DIR}/deploy/electron/electron/electron"
 elif [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
   CLI="${DIR}/deploy/electron/electron/electron.exe"
+elif [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
+  CLI="${DIR}/deploy/electron/electron/electron.exe"
 else
   echo "Cannot detect a supported OS."
   exit 1


### PR DESCRIPTION
Disclaimer: I read in the contribution guidelines, that you do not want contributions to "scripts" ... 

Anyway I thought I would add that a windows build does also work without cygwin installed (which is kind of a 'heavy' environment). 

I found that an installed GIT is sufficient to build LightTable, since it includes a "bash" shell. Therefore I added inside the build and start scripts the check for the MINGW environment and put another chapter in the documentation for people, that do not want to install cygwin. 