### PR TITLE
#2313 More portable nix/bash detection to include mingw

### DIFF
--- a/script/light.sh
+++ b/script/light.sh
@@ -10,7 +10,7 @@ DIR=$(pwd)
 
 if [ "$(uname)" == "Darwin" ]; then
   CLI="${DIR}/deploy/electron/electron/Electron.app/Contents/MacOS/Electron"
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif hash bash 2>/dev/null; then
   CLI="${DIR}/deploy/electron/electron/electron"
 elif [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
   CLI="${DIR}/deploy/electron/electron/electron.exe"


### PR DESCRIPTION
Mingw doesn't seem to have `expr` in its environment so the script failed to detect when run in e.g. Git Bash on Windows. This would fix it and should work on any Linux at the same time. I installed Cygwin just to ensure that the generic second condition wouldn't override Cygwin last, it doesn't.