### PR TITLE
Remove unused dataTransfer code from dragdrop.js

### DIFF
--- a/deploy/core/node_modules/lighttable/ui/dragdrop.js
+++ b/deploy/core/node_modules/lighttable/ui/dragdrop.js
@@ -13,9 +13,6 @@ function initSortable(window) {
     }
 
     function dragStart(e) {
-      var dt = e.dataTransfer;
-      dt.effectAllowed = 'move';
-      dt.setData('Text', 'dummy');
       dragging = this;
       dom.add_class(me, "dragging");
       //placeholder = dom.make(dragging.outerHTML)[0];


### PR DESCRIPTION
Some scaffolding around drag and drop dataTransfer objects was causing LightTable/LightTable#2342

I've just taken the problematic code out and not replaced it with anything.